### PR TITLE
b/361453823 Provision folder-, organization-level access

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/IamRoleBinding.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/IamRoleBinding.java
@@ -51,7 +51,7 @@ public record IamRoleBinding(
       this.description,
       String.format("%s on %s",
         this.role,
-        this.resource));
+        this.resource.path()));
   }
 
   public IamRoleBinding(

--- a/sources/src/main/java/com/google/solutions/jitaccess/util/Cast.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/util/Cast.java
@@ -1,0 +1,47 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+/**
+ * Utility methods for casting.
+ */
+public class Cast {
+  /**
+   * Cast the object to TTarget if possible, otherwise return empty.
+   *
+   * Similar to the C# 'as' operator.
+   */
+  public static <TSource, TTarget extends TSource> @NotNull Optional<TTarget> as(
+    @NotNull TSource obj,
+    @NotNull Class<TTarget> cls
+  ) {
+    if (cls.isInstance(obj)) {
+      return Optional.of(cls.cast(obj));
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/util/Cast.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/util/Cast.java
@@ -34,7 +34,7 @@ public class Cast {
    *
    * Similar to the C# 'as' operator.
    */
-  public static <TSource, TTarget extends TSource> @NotNull Optional<TTarget> as(
+  public static <TSource, TTarget extends TSource> @NotNull Optional<TTarget> tryCast(
     @NotNull TSource obj,
     @NotNull Class<TTarget> cls
   ) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/util/MoreStrings.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/util/MoreStrings.java
@@ -21,27 +21,16 @@
 
 package com.google.solutions.jitaccess.util;
 
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Utility methods for casting.
+ * Utility methods for working with strings.
  */
-public abstract class Cast {
+public abstract class MoreStrings {
   /**
-   * Cast the object to TTarget if possible, otherwise return empty.
-   *
-   * Similar to the C# 'as' operator.
+   * Check if a string is null or only contains whitespace
    */
-  public static <TSource, TTarget extends TSource> @NotNull Optional<TTarget> tryCast(
-    @NotNull TSource obj,
-    @NotNull Class<TTarget> cls
-  ) {
-    if (cls.isInstance(obj)) {
-      return Optional.of(cls.cast(obj));
-    } else {
-      return Optional.empty();
-    }
+  public static boolean isNullOrBlank(@Nullable String s) {
+    return s == null || s.isBlank();
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestProvisioner.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestProvisioner.java
@@ -357,13 +357,28 @@ public class TestProvisioner {
   @Nested
   public static class IamProvisioner {
 
-
     // -------------------------------------------------------------------------
     // replaceBindingsForPrincipals.
     // -------------------------------------------------------------------------
 
     @Test
-    public void replaceBindingsForPrincipals_whenExistingPoliciesHasObsoleteBindings() {
+    public void replaceBindingsForPrincipals_whenExistingPolicyHasNoBindings() {
+      var policy = new Policy();
+
+      Provisioner.IamProvisioner.replaceBindingsForPrincipals(
+        policy,
+        SAMPLE_USER_1,
+        List.of(new IamRoleBinding(SAMPLE_PROJECT_1, SAMPLE_ROLE_3)));
+
+      assertEquals(1, policy.getBindings().size());
+
+      assertEquals("roles/role-3", policy.getBindings().get(0).getRole());
+      assertEquals(1, policy.getBindings().get(0).getMembers().size());
+      assertEquals("user:" + SAMPLE_USER_1.email, policy.getBindings().get(0).getMembers().get(0));
+    }
+
+    @Test
+    public void replaceBindingsForPrincipals_whenExistingPolicyHasObsoleteBindings() {
       var role1 = new Binding()
         .setRole("roles/role-1")
         .setMembers(new ArrayList<>(List.of(

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestProvisioner.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestProvisioner.java
@@ -25,7 +25,9 @@ import com.google.api.services.cloudidentity.v1.model.EntityKey;
 import com.google.api.services.cloudidentity.v1.model.Group;
 import com.google.api.services.cloudresourcemanager.v3.model.Binding;
 import com.google.api.services.cloudresourcemanager.v3.model.Policy;
+import com.google.solutions.jitaccess.apis.FolderId;
 import com.google.solutions.jitaccess.apis.IamRole;
+import com.google.solutions.jitaccess.apis.OrganizationId;
 import com.google.solutions.jitaccess.apis.ProjectId;
 import com.google.solutions.jitaccess.apis.clients.*;
 import com.google.solutions.jitaccess.catalog.auth.GroupId;
@@ -59,6 +61,8 @@ public class TestProvisioner {
   private static final GroupId SAMPLE_GROUP = new GroupId("group@example.com");
   private static final ProjectId SAMPLE_PROJECT_1 = new ProjectId("project-1");
   private static final ProjectId SAMPLE_PROJECT_2 = new ProjectId("project-2");
+  private static final FolderId SAMPLE_FOLDER = new FolderId("1");
+  private static final OrganizationId SAMPLE_ORGANIZATION = new OrganizationId("1");
   private static final IamRole SAMPLE_ROLE_1 = new IamRole("roles/role-1");
   private static final IamRole SAMPLE_ROLE_2 = new IamRole("roles/role-2");
   private static final IamRole SAMPLE_ROLE_3 = new IamRole("roles/role-3");
@@ -498,12 +502,19 @@ public class TestProvisioner {
         Set.of(
           new IamRoleBinding(SAMPLE_PROJECT_1, SAMPLE_ROLE_1),
           new IamRoleBinding(SAMPLE_PROJECT_1, SAMPLE_ROLE_2),
-          new IamRoleBinding(SAMPLE_PROJECT_2, SAMPLE_ROLE_2)));
+          new IamRoleBinding(SAMPLE_PROJECT_2, SAMPLE_ROLE_2),
+          new IamRoleBinding(SAMPLE_FOLDER, SAMPLE_ROLE_2),
+          new IamRoleBinding(SAMPLE_ORGANIZATION, SAMPLE_ROLE_2)));
 
       verify(resourceManagerClient, times(1))
         .modifyIamPolicy(eq(SAMPLE_PROJECT_1), any(), any());
       verify(resourceManagerClient, times(1))
         .modifyIamPolicy(eq(SAMPLE_PROJECT_2), any(), any());
+      verify(resourceManagerClient, times(1))
+        .modifyIamPolicy(eq(SAMPLE_FOLDER), any(), any());
+      verify(resourceManagerClient, times(1))
+        .modifyIamPolicy(eq(SAMPLE_ORGANIZATION), any(), any());
+
       verify(groupsClient, times(1)).patchGroup(
         any(),
         eq("Test group #69092b7d"));

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestIamRoleBinding.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestIamRoleBinding.java
@@ -55,7 +55,7 @@ public class TestIamRoleBinding {
       new ProjectId("project-1"),
       new IamRole("roles/viewer"));
 
-    assertEquals("roles/viewer on project-1", binding.toString());
+    assertEquals("roles/viewer on projects/project-1", binding.toString());
   }
 
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/util/TestCast.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/util/TestCast.java
@@ -1,0 +1,42 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestCast {
+  @Test
+  public void as_whenIncompatible() {
+    assertFalse(Cast.as(1, String.class).isPresent());
+  }
+
+  @Test
+  public void as_whenCompatible() {
+    assertTrue(Cast.as(1, Number.class).isPresent());
+    assertEquals(1, Cast.as(1, Number.class).get());
+
+    assertTrue(Cast.as("test", String.class).isPresent());
+    assertEquals("test", Cast.as("test", String.class).get());
+  }
+}

--- a/sources/src/test/java/com/google/solutions/jitaccess/util/TestCast.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/util/TestCast.java
@@ -27,16 +27,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCast {
   @Test
-  public void as_whenIncompatible() {
-    assertFalse(Cast.as(1, String.class).isPresent());
+  public void tryCast_whenIncompatible() {
+    assertFalse(Cast.tryCast(1, String.class).isPresent());
   }
 
   @Test
-  public void as_whenCompatible() {
-    assertTrue(Cast.as(1, Number.class).isPresent());
-    assertEquals(1, Cast.as(1, Number.class).get());
+  public void tryCast_whenCompatible() {
+    assertTrue(Cast.tryCast(1, Number.class).isPresent());
+    assertEquals(1, Cast.tryCast(1, Number.class).get());
 
-    assertTrue(Cast.as("test", String.class).isPresent());
-    assertEquals("test", Cast.as("test", String.class).get());
+    assertTrue(Cast.tryCast("test", String.class).isPresent());
+    assertEquals("test", Cast.tryCast("test", String.class).get());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/util/TestMoreStrings.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/util/TestMoreStrings.java
@@ -21,27 +21,27 @@
 
 package com.google.solutions.jitaccess.util;
 
-import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Utility methods for casting.
- */
-public abstract class Cast {
-  /**
-   * Cast the object to TTarget if possible, otherwise return empty.
-   *
-   * Similar to the C# 'as' operator.
-   */
-  public static <TSource, TTarget extends TSource> @NotNull Optional<TTarget> tryCast(
-    @NotNull TSource obj,
-    @NotNull Class<TTarget> cls
-  ) {
-    if (cls.isInstance(obj)) {
-      return Optional.of(cls.cast(obj));
-    } else {
-      return Optional.empty();
-    }
+public class TestMoreStrings {
+  @Test
+  public void isNullOrBlank_whenNull() {
+    assertTrue(MoreStrings.isNullOrBlank(null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ",  "\n\t"})
+  public void isNullOrBlank_whenBlank(String s) {
+    assertTrue(MoreStrings.isNullOrBlank(s));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"x", " x",  "\n\tx"})
+  public void isNullOrBlank_whenNotBlank(String s) {
+    assertFalse(MoreStrings.isNullOrBlank(s));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestGroupsResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestGroupsResource.java
@@ -125,7 +125,7 @@ public class TestGroupsResource {
     assertEquals(group.name(), groupInfo.name());
     assertEquals(group.description(), groupInfo.description());
     assertEquals(2, groupInfo.privileges().size());
-    assertEquals("roles/role-1 on project-1", groupInfo.privileges().get(0).description());
+    assertEquals("roles/role-1 on projects/project-1", groupInfo.privileges().get(0).description());
     assertEquals("description", groupInfo.privileges().get(1).description());
     assertEquals(group.system().name(), groupInfo.system().name());
     assertEquals(group.system().description(), groupInfo.system().description());

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestProposalResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestProposalResource.java
@@ -178,7 +178,7 @@ public class TestProposalResource {
     assertEquals(group.name(), groupInfo.name());
     assertEquals(group.description(), groupInfo.description());
     assertEquals(2, groupInfo.privileges().size());
-    assertEquals("roles/role-1 on project-1", groupInfo.privileges().get(0).description());
+    assertEquals("roles/role-1 on projects/project-1", groupInfo.privileges().get(0).description());
     assertEquals("description", groupInfo.privileges().get(1).description());
     assertEquals(group.system().name(), groupInfo.system().name());
     assertEquals(group.system().description(), groupInfo.system().description());
@@ -216,7 +216,7 @@ public class TestProposalResource {
     assertEquals(group.name(), groupInfo.name());
     assertEquals(group.description(), groupInfo.description());
     assertEquals(2, groupInfo.privileges().size());
-    assertEquals("roles/role-1 on project-1", groupInfo.privileges().get(0).description());
+    assertEquals("roles/role-1 on projects/project-1", groupInfo.privileges().get(0).description());
     assertEquals("description", groupInfo.privileges().get(1).description());
     assertEquals(group.system().name(), groupInfo.system().name());
     assertEquals(group.system().description(), groupInfo.system().description());


### PR DESCRIPTION
- Introduce `resource` attribute in policy, which can refer to a project, folder, or organization ID
- Extend provisioning logic to modify folder or organization IAM policies