### PR TITLE
b/363121046 Allow unnamed policies

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/PolicyResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/PolicyResource.java
@@ -21,8 +21,10 @@
 
 package com.google.solutions.jitaccess.web.rest;
 
+import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.catalog.policy.Policy;
 import com.google.solutions.jitaccess.catalog.policy.PolicyDocument;
+import com.google.solutions.jitaccess.util.MoreStrings;
 import com.google.solutions.jitaccess.web.LogRequest;
 import com.google.solutions.jitaccess.web.RequireIapPrincipal;
 import jakarta.enterprise.context.Dependent;
@@ -49,12 +51,22 @@ public class PolicyResource {
   public @NotNull LintingResultInfo lint(
     @FormParam("source") @Nullable String source
   ) {
-    // TODO: check source != null
+    Preconditions.checkArgument(
+      !MoreStrings.isNullOrBlank(source),
+      "Source must not be empty");
 
     try {
+      //
+      // NB. It's possible that the user is validating that doesn't
+      //     explicitly specify a name (because it's implied).
+      //
       PolicyDocument.fromString(
         source,
-        new Policy.Metadata("user-provided", Instant.now()));
+        new Policy.Metadata(
+          "user-provided",
+          Instant.now(),
+          null,
+          "anonymous")); // Accept policies without name.
     }
     catch (PolicyDocument.SyntaxException e) {
       return LintingResultInfo.create(e);

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestPolicyResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestPolicyResource.java
@@ -25,11 +25,14 @@ import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
 import com.google.solutions.jitaccess.catalog.policy.Policy;
 import com.google.solutions.jitaccess.catalog.policy.PolicyDocument;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
 
 import static io.smallrye.common.constraint.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestPolicyResource {
   //---------------------------------------------------------------------------
@@ -37,13 +40,36 @@ public class TestPolicyResource {
   //---------------------------------------------------------------------------
 
   @Test
-  public void lint_whenPolicyMalformed() {
+  public void lint_whenPolicyNull() {
     var resource = new PolicyResource();
 
-    var result = resource.lint("invalid:;)");
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> resource.lint(null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"-", ";", "invalid:;)"})
+  public void lint_whenPolicyMalformed(String source) {
+    var resource = new PolicyResource();
+
+    var result = resource.lint(source);
 
     assertFalse(result.successful());
     assertFalse(result.issues().isEmpty());
+  }
+
+  @Test
+  public void lint_whenPolicyHasNoName() {
+    var resource = new PolicyResource();
+
+    var result = resource.lint(
+      "schemaVersion: 1\n" +
+      "environment:\n" +
+      "  name: \"\"");
+
+    assertTrue(result.successful());
+    assertTrue(result.issues().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Allow unnnamed environment policies when linting
policy documents because users might be validating policies whose name was implied from the
environment's service account.