### PR TITLE
b/364159878 Replace UserId with more specific principal ID

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -222,13 +222,13 @@ public class Application {
           applicationCredentials.refresh();
           applicationPrincipal = impersonateServiceAccount.get();
         }
-        else if (defaultCredentials instanceof ServiceAccountCredentials) {
+        else if (defaultCredentials instanceof ServiceAccountCredentials saCredentials) {
           //
           // Use ADC as-is.
           //
           applicationCredentials = defaultCredentials;
           applicationPrincipal = ServiceAccountId
-            .parse(((ServiceAccountCredentials) applicationCredentials).getServiceAccountUser()) // TODO: add helper
+            .parse(saCredentials.getServiceAccountUser())
             .get();
         }
         else {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
@@ -193,7 +193,7 @@ class EnvironmentConfiguration implements PolicyHeader {
    */
   static @NotNull EnvironmentConfiguration forServiceAccount(
     @NotNull ServiceAccountId serviceAccountId,
-    @NotNull UserId applicationPrincipal,
+    @NotNull ServiceAccountId applicationPrincipal,
     @NotNull GoogleCredentials applicationCredentials,
     @NotNull HttpTransport.Options httpOptions
   ) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ServiceAccountSigner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ServiceAccountSigner.java
@@ -26,6 +26,7 @@ import com.google.auth.oauth2.TokenVerifier;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.apis.clients.AccessException;
 import com.google.solutions.jitaccess.apis.clients.IamCredentialsClient;
+import com.google.solutions.jitaccess.catalog.auth.ServiceAccountId;
 import com.google.solutions.jitaccess.catalog.auth.UserId;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
@@ -55,8 +56,8 @@ public class ServiceAccountSigner implements TokenSigner {
     this.tokenVerifier = TokenVerifier
       .newBuilder()
       .setCertificatesLocation(IamCredentialsClient.getJwksUrl(options.serviceAccount))
-      .setIssuer(options.serviceAccount.email)
-      .setAudience(options.serviceAccount.email)
+      .setIssuer(options.serviceAccount.value())
+      .setAudience(options.serviceAccount.value())
       .build();
   }
 
@@ -74,8 +75,8 @@ public class ServiceAccountSigner implements TokenSigner {
     //
     var issueTime = Instant.now();
     var jwtPayload =  payload
-      .setAudience(this.options.serviceAccount.email)
-      .setIssuer(this.options.serviceAccount.email)
+      .setAudience(this.options.serviceAccount.value())
+      .setIssuer(this.options.serviceAccount.value())
       .setIssuedAtTimeSeconds(issueTime.getEpochSecond())
       .setExpirationTimeSeconds(expiry.getEpochSecond());
 
@@ -113,7 +114,7 @@ public class ServiceAccountSigner implements TokenSigner {
 
 
   public record Options(
-    @NotNull UserId serviceAccount
+    @NotNull ServiceAccountId serviceAccount
   ) {
     public Options {
       Preconditions.checkNotNull(serviceAccount);

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
@@ -534,7 +534,7 @@ public class ITestCloudIdentityGroupsClient {
 
     var membership = memberships
       .stream()
-      .filter(m -> m.getPreferredMemberKey().getId().equals(ITestEnvironment.TEMPORARY_ACCESS_USER.toString()))
+      .filter(m -> m.getPreferredMemberKey().getId().equals(ITestEnvironment.TEMPORARY_ACCESS_USER.value()))
       .findFirst();
 
     assertTrue(membership.isPresent());

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestEnvironment.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestEnvironment.java
@@ -26,6 +26,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.apis.ProjectId;
+import com.google.solutions.jitaccess.catalog.auth.ServiceAccountId;
 import com.google.solutions.jitaccess.catalog.auth.UserId;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -54,12 +55,12 @@ public class ITestEnvironment {
   /**
    * Service account that tests can use to grant temporary access to.
    */
-  public static final UserId TEMPORARY_ACCESS_USER;
+  public static final ServiceAccountId TEMPORARY_ACCESS_USER;
 
   /**
    * Service account that doesn't have access to anything.
    */
-  public static final UserId NO_ACCESS_USER;
+  public static final ServiceAccountId NO_ACCESS_USER;
 
   /**
    * Credentials with application-level access.
@@ -114,11 +115,9 @@ public class ITestEnvironment {
       // User settings.
       //
 
-      NO_ACCESS_USER = new UserId(
-        String.format("%s@%s.iam.gserviceaccount.com", "no-access", PROJECT_ID));
+      NO_ACCESS_USER = new ServiceAccountId("no-access", PROJECT_ID);
 
-      TEMPORARY_ACCESS_USER = new UserId(
-        String.format("%s@%s.iam.gserviceaccount.com", "temporary-access", PROJECT_ID));
+      TEMPORARY_ACCESS_USER = new ServiceAccountId("temporary-access", PROJECT_ID);
 
       var defaultCredentials = GoogleCredentials
         .getApplicationDefault()
@@ -132,8 +131,8 @@ public class ITestEnvironment {
         APPLICATION_CREDENTIALS = defaultCredentials;
       }
 
-      NO_ACCESS_CREDENTIALS = impersonate(defaultCredentials, NO_ACCESS_USER.email);
-      TEMPORARY_ACCESS_CREDENTIALS = impersonate(defaultCredentials, TEMPORARY_ACCESS_USER.email);
+      NO_ACCESS_CREDENTIALS = impersonate(defaultCredentials, NO_ACCESS_USER.value());
+      TEMPORARY_ACCESS_CREDENTIALS = impersonate(defaultCredentials, TEMPORARY_ACCESS_USER.value());
 
       //
       // Pub/Sub settings.

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestIamCredentialsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestIamCredentialsClient.java
@@ -55,8 +55,8 @@ public class ITestIamCredentialsClient {
     var serviceAccount = ITestEnvironment.NO_ACCESS_USER;
 
     var payload = new JsonWebToken.Payload()
-      .setAudience(serviceAccount.email)
-      .setIssuer(serviceAccount.email);
+      .setAudience(serviceAccount.value())
+      .setIssuer(serviceAccount.value());
 
     var jwt = adapter.signJwt(serviceAccount, payload);
     assertNotNull(jwt);
@@ -64,8 +64,8 @@ public class ITestIamCredentialsClient {
     TokenVerifier
       .newBuilder()
       .setCertificatesLocation(IamCredentialsClient.getJwksUrl(serviceAccount))
-      .setIssuer(serviceAccount.email)
-      .setAudience(serviceAccount.email)
+      .setIssuer(serviceAccount.value())
+      .setAudience(serviceAccount.value())
       .build()
       .verify(jwt);
   }
@@ -79,7 +79,7 @@ public class ITestIamCredentialsClient {
     assertEquals(
       String.format(
         "https://www.googleapis.com/service_accounts/v1/metadata/jwk/%s",
-        ITestEnvironment.NO_ACCESS_USER.email),
+        ITestEnvironment.NO_ACCESS_USER.value()),
       IamCredentialsClient.getJwksUrl(ITestEnvironment.NO_ACCESS_USER));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestEnvironmentConfiguration.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestEnvironmentConfiguration.java
@@ -106,7 +106,7 @@ public class TestEnvironmentConfiguration {
       IllegalArgumentException.class,
       () -> EnvironmentConfiguration.forServiceAccount(
         new ServiceAccountId("no-prefix", new ProjectId("project-1")),
-        new UserId("app@example.com"),
+        new ServiceAccountId("app", new ProjectId("project-1")),
         Mockito.mock(GoogleCredentials.class),
         HttpTransport.Options.DEFAULT));
   }
@@ -115,7 +115,7 @@ public class TestEnvironmentConfiguration {
   public void forServiceAccount() {
     var configuration = EnvironmentConfiguration.forServiceAccount(
       new ServiceAccountId("jit-environment", new ProjectId("project-1")),
-      new UserId("app@example.com"),
+      new ServiceAccountId("app", new ProjectId("project-1")),
       Mockito.mock(GoogleCredentials.class),
       HttpTransport.Options.DEFAULT);
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/ITestServiceAccountSigner.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/ITestServiceAccountSigner.java
@@ -67,14 +67,14 @@ public class ITestServiceAccountSigner {
     var verifiedPayload = TokenVerifier
       .newBuilder()
       .setCertificatesLocation(IamCredentialsClient.getJwksUrl(serviceAccount))
-      .setIssuer(serviceAccount.email)
-      .setAudience(serviceAccount.email)
+      .setIssuer(serviceAccount.value())
+      .setAudience(serviceAccount.value())
       .build()
       .verify(token.token())
       .getPayload();
 
-    assertEquals(serviceAccount.email, verifiedPayload.getIssuer());
-    assertEquals(serviceAccount.email, verifiedPayload.getAudience());
+    assertEquals(serviceAccount.value(), verifiedPayload.getIssuer());
+    assertEquals(serviceAccount.value(), verifiedPayload.getAudience());
     assertEquals(token.issueTime().getEpochSecond(), verifiedPayload.getIssuedAtTimeSeconds());
     assertEquals(token.expiryTime().getEpochSecond(), verifiedPayload.getExpirationTimeSeconds());
   }
@@ -95,7 +95,7 @@ public class ITestServiceAccountSigner {
       new ServiceAccountSigner.Options(serviceAccount));
 
     var payload = new JsonWebToken.Payload()
-      .setIssuer(serviceAccount.email);
+      .setIssuer(serviceAccount.value());
     var jwt = credentialsAdapter.signJwt(serviceAccount, payload);
 
     assertThrows(
@@ -115,7 +115,7 @@ public class ITestServiceAccountSigner {
       new ServiceAccountSigner.Options(serviceAccount));
 
     var payload = new JsonWebToken.Payload()
-      .setAudience(serviceAccount.email);
+      .setAudience(serviceAccount.value());
 
     var jwt = credentialsAdapter.signJwt(serviceAccount, payload);
 
@@ -136,8 +136,8 @@ public class ITestServiceAccountSigner {
       new ServiceAccountSigner.Options(serviceAccount));
 
     var payload = new JsonWebToken.Payload()
-      .setAudience(serviceAccount.email)
-      .setIssuer(serviceAccount.email);
+      .setAudience(serviceAccount.value())
+      .setIssuer(serviceAccount.value());
 
     var jwt = credentialsAdapter.signJwt(ITestEnvironment.NO_ACCESS_USER, payload);
 


### PR DESCRIPTION
- Use `ServiceAccountId` instead of `UserId` where a service account must be used
- Use `IamPrincipalId` where a service account or group may be used