### PR TITLE
b/364159878 Expose directory information in Subject

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/Subject.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/Subject.java
@@ -30,12 +30,17 @@ import java.util.Set;
  */
 public interface Subject {
   /**
-   * @return Primary id.
+   * Get the ID of the authenticated user.
    */
   @NotNull EndUserId user();
 
   /**
-   * @return full set of principals, including groups and roles.
+   * Get directory that the user originates from.
+   */
+  public @NotNull Directory directory();
+
+  /**
+   * Get the user's full set of principals, including groups and roles.
    */
   @NotNull Set<Principal> principals();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
@@ -34,10 +34,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -63,7 +60,7 @@ public class SubjectResolver {
     this.logger = logger;
   }
 
-  @NotNull Set<Principal> resolveMemberships(
+  @NotNull Set<Principal> resolveJitGroupMemberships(
     @NotNull EndUserId user,
     @NotNull List<UnresolvedMembership> memberships
   ) {
@@ -145,15 +142,15 @@ public class SubjectResolver {
   }
 
   /**
-   * Build a subject for a given user. The subject includes all the user's
-   * principals, including:
+   * Lookup all of a user's principals. These include:
    *
-   * - the user's ID
-   * - roles
-   * - groups
-   *
+   * <ul>
+   *   <li>The user itself</li>
+   *   <li>JIT Group memberships</li>
+   *   <li>Other group memberships</li>
+   * </ul>
    */
-  public @NotNull Subject resolve(
+  protected @NotNull Set<Principal> lookupPrincipals(
     @NotNull EndUserId user
   ) throws AccessException, IOException {
     //
@@ -216,7 +213,7 @@ public class SubjectResolver {
       .flatMap(m -> m.getRoles().stream())
       .allMatch(r -> r.getExpiryDetail() == null);
 
-    var jitGroupPrincipals = resolveMemberships(user, jitGroupMemberships);
+    var jitGroupPrincipals = resolveJitGroupMemberships(user, jitGroupMemberships);
 
     var allPrincipals = new HashSet<Principal>();
     allPrincipals.add(new Principal(UserClassId.IAP_USERS));
@@ -230,6 +227,24 @@ public class SubjectResolver {
         user,
         jitGroupPrincipals.size(),
         otherGroupPrincipals.size()));
+
+    return allPrincipals;
+  }
+
+  /**
+   * Build a subject for a given user. The subject includes all the user's
+   * principals, including:
+   *
+   * - the user's ID
+   * - roles
+   * - groups
+   *
+   */
+  public @NotNull Subject resolve(
+    @NotNull EndUserId user
+  ) throws AccessException, IOException {
+    var allPrincipals = lookupPrincipals(user);
+    assert allPrincipals.stream().anyMatch(p -> p.id().equals(user));
 
     return new Subject() {
       @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
@@ -241,7 +241,8 @@ public class SubjectResolver {
    *
    */
   public @NotNull Subject resolve(
-    @NotNull EndUserId user
+    @NotNull EndUserId user,
+    @NotNull Directory directory
   ) throws AccessException, IOException {
     var allPrincipals = lookupPrincipals(user);
     assert allPrincipals.stream().anyMatch(p -> p.id().equals(user));
@@ -250,6 +251,11 @@ public class SubjectResolver {
       @Override
       public @NotNull EndUserId user() {
         return user;
+      }
+
+      @Override
+      public @NotNull Directory directory() {
+        return directory;
       }
 
       @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -196,7 +196,8 @@ public class Application {
       try {
         var defaultCredentials = GoogleCredentials.getApplicationDefault();
 
-        var impersonateServiceAccount = ServiceAccountId.parse(System.getProperty(CONFIG_IMPERSONATE_SA));
+        var impersonateServiceAccount = ServiceAccountId.parse(
+          ServiceAccountId.TYPE + ":" + System.getProperty(CONFIG_IMPERSONATE_SA));
         if (impersonateServiceAccount.isPresent()) {
           //
           // Use the application default credentials (ADC) to impersonate a

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequestContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequestContext.java
@@ -22,6 +22,11 @@ public class RequestContext {
     }
 
     @Override
+    public @NotNull Directory directory() {
+      return Directory.PROJECT;
+    }
+
+    @Override
     public @NotNull Set<Principal> principals() {
       return Set.of(new Principal(user()));
     }
@@ -57,6 +62,7 @@ public class RequestContext {
    */
   void authenticate(
     @NotNull EndUserId userId,
+    @NotNull Directory directory,
     @NotNull Device device
   ) {
     if (isAuthenticated()) {
@@ -74,6 +80,11 @@ public class RequestContext {
       }
 
       @Override
+      public @NotNull Directory directory() {
+        return directory;
+      }
+
+      @Override
       public @NotNull Set<Principal> principals() {
         //
         // Resolve lazily.
@@ -82,7 +93,9 @@ public class RequestContext {
         {
           if (this.cachedPrincipals == null) {
             try {
-              this.cachedPrincipals = RequestContext.this.subjectResolver.resolve(this.user()).principals();
+              this.cachedPrincipals = RequestContext.this.subjectResolver
+                .resolve(this.user(), this.directory())
+                .principals();
             }
             catch (AccessException | IOException e) {
               throw new UncheckedExecutionException(e);
@@ -132,6 +145,11 @@ public class RequestContext {
     @Override
     public @NotNull EndUserId user() {
       return this.subject.user();
+    }
+
+    @Override
+    public @NotNull Directory directory() {
+      return this.subject.directory();
     }
 
     @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequireIapPrincipalFilter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequireIapPrincipalFilter.java
@@ -24,6 +24,7 @@ package com.google.solutions.jitaccess.web;
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.catalog.Logger;
+import com.google.solutions.jitaccess.catalog.auth.Directory;
 import com.google.solutions.jitaccess.catalog.auth.EndUserId;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
@@ -86,6 +87,7 @@ public class RequireIapPrincipalFilter implements ContainerRequestFilter {
       if (verifiedAssertion.user() instanceof EndUserId endUserId) {
         this.requestContext.authenticate(
           endUserId,
+          verifiedAssertion.directory(),
           verifiedAssertion.device());
       }
       else  {
@@ -127,6 +129,7 @@ public class RequireIapPrincipalFilter implements ContainerRequestFilter {
 
     this.requestContext.authenticate(
       new EndUserId(debugPrincipalName),
+      new Directory("DEBUG"),
       IapDevice.UNKNOWN);
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/StructuredLogger.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/StructuredLogger.java
@@ -303,7 +303,6 @@ abstract class StructuredLogger implements Logger {
    */
   static class RequestContextLogger extends StructuredLogger {
     private final @NotNull RequestContext requestContext;
-    private @Nullable String traceId;
 
     RequestContextLogger(
       @NotNull Appendable output,
@@ -328,6 +327,7 @@ abstract class StructuredLogger implements Logger {
 
       if (this.requestContext.isAuthenticated()) {
         labels.put("auth/user_id", this.requestContext.user().email);
+        labels.put("auth/directory", this.requestContext.subject().directory().toString());
         labels.put("auth/device_id", this.requestContext.device().deviceId());
         labels.put("auth/device_access_levels",
           String.join(", ", this.requestContext.device().accessLevels()));

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCachedSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCachedSubjectResolver.java
@@ -34,9 +34,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class TestCachedSubjectResolver {
-  private final String SAMPLE_DOMAIN = "example.com";
-  private final EndUserId SAMPLE_USER = new EndUserId("user@example.com");
-  private final Executor EXECUTOR = command -> command.run();
+  private static final String SAMPLE_DOMAIN = "example.com";
+  private static final Directory SAMPLE_DIRECTORY = new Directory(SAMPLE_DOMAIN);
+  private static final EndUserId SAMPLE_USER = new EndUserId("user@example.com");
+  private static final Executor EXECUTOR = command -> command.run();
 
   //---------------------------------------------------------------------------
   // resolve
@@ -57,8 +58,8 @@ public class TestCachedSubjectResolver {
       Mockito.mock(Logger.class),
       new CachedSubjectResolver.Options(Duration.ofMinutes(1)));
 
-    resolver.resolve(SAMPLE_USER); // Triggers load
-    resolver.resolve(SAMPLE_USER); // Triggers cache
+    resolver.resolve(SAMPLE_USER, SAMPLE_DIRECTORY); // Triggers load
+    resolver.resolve(SAMPLE_USER, SAMPLE_DIRECTORY); // Triggers cache
 
     verify(groupsClient, times(1)).listMembershipsByUser(eq(SAMPLE_USER));
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
@@ -52,7 +52,7 @@ public class TestSubjectResolver {
   //---------------------------------------------------------------------------
 
   @Test
-  public void resolveMemberships_whenGroupHasMultipleExpiries_thenPrincipalUsesMinimum() throws Exception {
+  public void resolveJitGroupMemberships_whenGroupHasMultipleExpiries_thenPrincipalUsesMinimum() throws Exception {
     var mapping = new GroupMapping(SAMPLE_DOMAIN);
     var membershipId = new CloudIdentityGroupsClient.MembershipId("m1");
 
@@ -76,7 +76,7 @@ public class TestSubjectResolver {
       EXECUTOR,
       Mockito.mock(Logger.class));
 
-    var principals = resolver.resolveMemberships(
+    var principals = resolver.resolveJitGroupMemberships(
       SAMPLE_USER,
       List.of(new SubjectResolver.UnresolvedMembership(
         mapping.groupFromJitGroup(SAMPLE_JITGROUP),
@@ -90,7 +90,7 @@ public class TestSubjectResolver {
   }
 
   @Test
-  public void resolveMemberships_whenGroupLacksExpiry_thenGrouplIsIgnored() throws Exception {
+  public void resolveJitGroupMemberships_whenGroupLacksExpiry_thenGrouplIsIgnored() throws Exception {
     var mapping = new GroupMapping(SAMPLE_DOMAIN);
     var membershipId = new CloudIdentityGroupsClient.MembershipId("m1");
 
@@ -109,7 +109,7 @@ public class TestSubjectResolver {
       EXECUTOR,
       logger);
 
-    var principals = resolver.resolveMemberships(
+    var principals = resolver.resolveJitGroupMemberships(
       SAMPLE_USER,
       List.of(new SubjectResolver.UnresolvedMembership(
         mapping.groupFromJitGroup(SAMPLE_JITGROUP),
@@ -120,7 +120,7 @@ public class TestSubjectResolver {
   }
 
   @Test
-  public void resolveMemberships_whenLookupFails_thenGroupIsIgnored() throws Exception {
+  public void resolveJitGroupMemberships_whenLookupFails_thenGroupIsIgnored() throws Exception {
     var mapping = new GroupMapping(SAMPLE_DOMAIN);
     var membershipId = new CloudIdentityGroupsClient.MembershipId("m1");
 
@@ -135,7 +135,7 @@ public class TestSubjectResolver {
       EXECUTOR,
       logger);
 
-    var principals = resolver.resolveMemberships(
+    var principals = resolver.resolveJitGroupMemberships(
       SAMPLE_USER,
       List.of(new SubjectResolver.UnresolvedMembership(
         mapping.groupFromJitGroup(SAMPLE_JITGROUP),

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
@@ -34,8 +34,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -174,12 +173,13 @@ public class TestSubjectResolver {
       EXECUTOR,
       Mockito.mock(Logger.class));
 
-    var subject = resolver.resolve(SAMPLE_USER);
+    var subject = resolver.resolve(SAMPLE_USER, Directory.CONSUMER);
     var principals = subject.principals().stream()
       .map(p -> p.id())
       .collect(Collectors.toSet());
 
     assertEquals(SAMPLE_USER, subject.user());
+    assertSame(Directory.CONSUMER, subject.directory());
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
     assertTrue(principals.contains(SAMPLE_GROUP), "other group");
     assertTrue(principals.contains(SAMPLE_JITGROUP), "JIT group");

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestAccessControlList.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestAccessControlList.java
@@ -21,10 +21,8 @@
 
 package com.google.solutions.jitaccess.catalog.policy;
 
-import com.google.solutions.jitaccess.catalog.auth.GroupId;
-import com.google.solutions.jitaccess.catalog.auth.Principal;
-import com.google.solutions.jitaccess.catalog.auth.Subject;
-import com.google.solutions.jitaccess.catalog.auth.EndUserId;
+import com.google.solutions.jitaccess.catalog.auth.*;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -37,10 +35,12 @@ public class TestAccessControlList {
   private static final EndUserId TEST_USER = new EndUserId("test-1@example.com");
   private static final EndUserId TEST_USER_OTHER = new EndUserId("test-2@example.com");
   private static final GroupId TEST_GROUP_1 = new GroupId("group-1@example.com");
+  private static final Directory TEST_DIRECTORY = new Directory("example.com");
 
   private record TestSubject(
-    EndUserId user,
-    Set<Principal> principals) implements Subject {
+    @NotNull EndUserId user,
+    @NotNull Directory directory,
+    @NotNull Set<Principal> principals) implements Subject {
   }
 
   private static class Rights {
@@ -56,7 +56,7 @@ public class TestAccessControlList {
   @Test
   public void isAllowed_whenAclEmpty() {
     var acl = new AccessControlList(Set.of());
-    var subject = new TestSubject(TEST_USER, Set.of());
+    var subject = new TestSubject(TEST_USER, TEST_DIRECTORY, Set.of());
 
     assertFalse(acl.isAllowed(subject, Rights.READ));
     assertFalse(acl.isAllowed(subject, Rights.WRITE));
@@ -71,6 +71,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER)));
 
     assertFalse(acl.isAllowed(subject, Rights.READ));
@@ -87,6 +88,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER)));
 
     assertTrue(acl.isAllowed(subject, Rights.READ));
@@ -104,6 +106,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER), new Principal(TEST_GROUP_1)));
 
     assertTrue(acl.isAllowed(subject, Rights.READ));
@@ -120,6 +123,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER), new Principal(TEST_GROUP_1)));
 
     assertFalse(acl.isAllowed(subject, Rights.READ | Rights.WRITE));
@@ -134,6 +138,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(
         new Principal(TEST_USER),
         new Principal(TEST_GROUP_1, Instant.now().minusSeconds(10))));
@@ -155,6 +160,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER), new Principal(TEST_GROUP_1)));
 
     assertFalse(acl.isAllowed(subject, Rights.READ));
@@ -171,6 +177,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER), new Principal(TEST_GROUP_1)));
 
     assertTrue(acl.isAllowed(subject, Rights.READ | Rights.WRITE));
@@ -187,6 +194,7 @@ public class TestAccessControlList {
 
     var subject = new TestSubject(
       TEST_USER,
+      TEST_DIRECTORY,
       Set.of(new Principal(TEST_USER)));
 
     assertFalse(acl.isAllowed(subject, Rights.READ));

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestRequestContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestRequestContext.java
@@ -22,6 +22,7 @@
 package com.google.solutions.jitaccess.web;
 
 import com.google.solutions.jitaccess.catalog.Subjects;
+import com.google.solutions.jitaccess.catalog.auth.Directory;
 import com.google.solutions.jitaccess.catalog.auth.GroupId;
 import com.google.solutions.jitaccess.catalog.auth.SubjectResolver;
 import com.google.solutions.jitaccess.catalog.auth.EndUserId;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.*;
 public class TestRequestContext {
   private static final EndUserId SAMPLE_USER = new EndUserId("user-1@example.com");
   private static final GroupId SAMPLE_GROUP = new GroupId("group-1@example.com");
+  private static final Directory SAMPLE_DIRECTORY = new Directory("example.com");
 
   @Test
   public void whenNotAuthenticated() {
@@ -61,11 +63,11 @@ public class TestRequestContext {
     var subject = Subjects.createWithPrincipalIds(SAMPLE_USER, Set.of(SAMPLE_GROUP));
 
     var resolver = Mockito.mock(SubjectResolver.class);
-    when(resolver.resolve(eq(SAMPLE_USER)))
+    when(resolver.resolve(eq(SAMPLE_USER), eq(SAMPLE_DIRECTORY)))
       .thenReturn(subject);
 
     var context = new RequestContext(resolver);
-    context.authenticate(SAMPLE_USER, new IapDevice("device-1", List.of()));
+    context.authenticate(SAMPLE_USER, SAMPLE_DIRECTORY, new IapDevice("device-1", List.of()));
 
     assertEquals(SAMPLE_USER.email, context.subject().user().email);
     assertEquals(3, context.subject().principals().size());
@@ -73,6 +75,6 @@ public class TestRequestContext {
 
     assertEquals("device-1", context.device().deviceId());
 
-    verify(resolver, times(1)).resolve(eq(SAMPLE_USER));
+    verify(resolver, times(1)).resolve(eq(SAMPLE_USER), eq(SAMPLE_DIRECTORY));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestStructuredLogger.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestStructuredLogger.java
@@ -21,6 +21,7 @@
 
 package com.google.solutions.jitaccess.web;
 
+import com.google.solutions.jitaccess.catalog.auth.Directory;
 import com.google.solutions.jitaccess.catalog.auth.SubjectResolver;
 import com.google.solutions.jitaccess.catalog.auth.EndUserId;
 import org.junit.jupiter.api.Nested;
@@ -152,6 +153,7 @@ public class TestStructuredLogger {
       requestContext.initialize("GET", "/", "trace-1");
       requestContext.authenticate(
         new EndUserId("id"),
+        Directory.CONSUMER,
         new IapDevice("device-id", List.of()));
       var logger = new StructuredLogger.RequestContextLogger(buffer, requestContext);
 
@@ -173,6 +175,7 @@ public class TestStructuredLogger {
       requestContext.initialize("GET", "/", "trace-1");
       requestContext.authenticate(
         new EndUserId("id"),
+        Directory.CONSUMER,
         new IapDevice("device-id", List.of("level-1", "level-2")));
       var logger = new StructuredLogger.RequestContextLogger(buffer, requestContext);
 


### PR DESCRIPTION
Use directory information from JWT assertion and make it available in `Subject` so that it can be consumed by the application.