### PR TITLE
b/365005515 Add principal identifier to distinguish internal from external users

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CachedSubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CachedSubjectResolver.java
@@ -58,13 +58,13 @@ public class CachedSubjectResolver extends SubjectResolver {
 
         @Override
         public @NotNull Set<Principal> load(@NotNull EndUserId userId) throws Exception {
-          return CachedSubjectResolver.super.resolvePrincipals(userId);
+          return CachedSubjectResolver.super.resolveGroupPrincipals(userId);
         }
       });
   }
 
   @Override
-  public @NotNull Set<Principal> resolvePrincipals(
+  protected @NotNull Set<Principal> resolveGroupPrincipals(
     @NotNull EndUserId user
   ) throws AccessException, IOException {
     try {

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CachedSubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CachedSubjectResolver.java
@@ -50,7 +50,7 @@ public class CachedSubjectResolver extends SubjectResolver {
     @NotNull Logger logger,
     @NotNull Options options
   ) {
-    super(groupsClient, groupMapping, executor, logger);
+    super(groupsClient, groupMapping, options.internalDirectory, executor, logger);
 
     this.cache =  CacheBuilder.newBuilder()
       .expireAfterWrite(options.cacheDuration)
@@ -87,6 +87,7 @@ public class CachedSubjectResolver extends SubjectResolver {
    * Constructor options, injectable using CDI.
    */
   public record Options(
-    @NotNull Duration cacheDuration
+    @NotNull Duration cacheDuration,
+    @NotNull Directory internalDirectory
   ) {}
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/Directory.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/Directory.java
@@ -49,6 +49,10 @@ public record Directory(
     Preconditions.checkArgument(hostedDomain == null || hostedDomain.type() == Domain.Type.PRIMARY);
   }
 
+  public Directory(@NotNull Domain hostedDomain) {
+    this(Type.CLOUD_IDENTITY, hostedDomain);
+  }
+
   public Directory(@NotNull String hostedDomain) {
     this(Type.CLOUD_IDENTITY, new Domain(hostedDomain, Domain.Type.PRIMARY));
   }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/UserClassId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/UserClassId.java
@@ -44,7 +44,8 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
 
   /**
    * Principal identifier that identifies all users that
-   * belong to the local Cloud Identity/Workspace account.
+   * belong to the "internal" Cloud Identity/Workspace account, i.e.,
+   * the account that this instance of JIT Groups is associated with.
    *
    * Consumer accounts and service accounts are not considered
    * internal.
@@ -53,7 +54,7 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
 
   /**
    * Principal identifier that identifies all users that
-   * do not belong to the local Cloud Identity/Workspace account,
+   * do not belong to the internal Cloud Identity/Workspace account,
    * including consumer accounts and service accounts.
    */
   public static final @NotNull UserClassId EXTERNAL_USERS = new UserClassId("externalUsers");

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/UserClassId.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/UserClassId.java
@@ -24,6 +24,7 @@ package com.google.solutions.jitaccess.catalog.auth;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -41,6 +42,27 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
    */
   public static final @NotNull UserClassId IAP_USERS = new UserClassId("iapUsers");
 
+  /**
+   * Principal identifier that identifies all users that
+   * belong to the local Cloud Identity/Workspace account.
+   *
+   * Consumer accounts and service accounts are not considered
+   * internal.
+   */
+  public static final @NotNull UserClassId INTERNAL_USERS = new UserClassId("internalUsers");
+
+  /**
+   * Principal identifier that identifies all users that
+   * do not belong to the local Cloud Identity/Workspace account,
+   * including consumer accounts and service accounts.
+   */
+  public static final @NotNull UserClassId EXTERNAL_USERS = new UserClassId("externalUsers");
+
+  private static final Map<String, UserClassId> PARSE_MAP = Map.of(
+    IAP_USERS.toString().toLowerCase(), IAP_USERS,
+    INTERNAL_USERS.toString().toLowerCase(), INTERNAL_USERS,
+    EXTERNAL_USERS.toString().toLowerCase(), EXTERNAL_USERS);
+
   @SuppressWarnings("SameParameterValue")
   private UserClassId(@NotNull String value) {
     this.value = value;
@@ -54,14 +76,7 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
       return Optional.empty();
     }
 
-    s = s.trim();
-
-    if (s.equalsIgnoreCase(IAP_USERS.toString())) {
-      return Optional.of(IAP_USERS);
-    }
-    else {
-      return Optional.empty();
-    }
+    return Optional.ofNullable(PARSE_MAP.get(s.trim().toLowerCase()));
   }
 
   // -------------------------------------------------------------------------

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -340,7 +340,9 @@ public class Application {
     // load can benefit from it, but short enough so that new group
     // memberships are applied without substantial extra delay.
     //
-    return new CachedSubjectResolver.Options(Duration.ofSeconds(30));
+    return new CachedSubjectResolver.Options(
+      Duration.ofSeconds(30),
+      new Directory(configuration.primaryDomain));
   }
 
   @Produces

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequestContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequestContext.java
@@ -95,7 +95,7 @@ public class RequestContext {
             try {
               this.cachedPrincipals = RequestContext.this
                 .subjectResolver
-                .resolvePrincipals(this.user());
+                .resolvePrincipals(this.user(), directory);
             }
             catch (AccessException | IOException e) {
               throw new UncheckedExecutionException(e);

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCachedSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCachedSubjectResolver.java
@@ -56,7 +56,9 @@ public class TestCachedSubjectResolver {
       mapping,
       EXECUTOR,
       Mockito.mock(Logger.class),
-      new CachedSubjectResolver.Options(Duration.ofMinutes(1)));
+      new CachedSubjectResolver.Options(
+        Duration.ofMinutes(1),
+        new Directory(SAMPLE_DOMAIN)));
 
     resolver.resolveGroupPrincipals(SAMPLE_USER); // Triggers load
     resolver.resolveGroupPrincipals(SAMPLE_USER); // Triggers cache

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCachedSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCachedSubjectResolver.java
@@ -58,8 +58,8 @@ public class TestCachedSubjectResolver {
       Mockito.mock(Logger.class),
       new CachedSubjectResolver.Options(Duration.ofMinutes(1)));
 
-    resolver.resolvePrincipals(SAMPLE_USER); // Triggers load
-    resolver.resolvePrincipals(SAMPLE_USER); // Triggers cache
+    resolver.resolveGroupPrincipals(SAMPLE_USER); // Triggers load
+    resolver.resolveGroupPrincipals(SAMPLE_USER); // Triggers cache
 
     verify(groupsClient, times(1)).listMembershipsByUser(eq(SAMPLE_USER));
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestUserClassId.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestUserClassId.java
@@ -98,7 +98,25 @@ public class TestUserClassId {
     " class:iapUsers",
     "class:IAPUSERS  "
   })
-  public void parse(String s) {
+  public void parse_iapUsers(String s) {
     assertEquals(UserClassId.IAP_USERS, UserClassId.parse(s).get());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    " class:internalUsers",
+    "class:INTERNALUSERS  "
+  })
+  public void parse_internalUsers(String s) {
+    assertEquals(UserClassId.INTERNAL_USERS, UserClassId.parse(s).get());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    " class:externalUsers",
+    "class:EXTERNALUSERS  "
+  })
+  public void parse_externalUsers(String s) {
+    assertEquals(UserClassId.EXTERNAL_USERS, UserClassId.parse(s).get());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestRequestContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestRequestContext.java
@@ -57,7 +57,7 @@ public class TestRequestContext {
   @Test
   public void whenAuthenticated() throws Exception {
     var resolver = Mockito.mock(SubjectResolver.class);
-    when(resolver.resolvePrincipals(eq(SAMPLE_USER)))
+    when(resolver.resolvePrincipals(eq(SAMPLE_USER), eq(SAMPLE_DIRECTORY)))
       .thenReturn(Set.of(
         new Principal(SAMPLE_USER),
         new Principal(SAMPLE_GROUP)));
@@ -71,6 +71,6 @@ public class TestRequestContext {
 
     assertEquals("device-1", context.device().deviceId());
 
-    verify(resolver, times(1)).resolvePrincipals(eq(SAMPLE_USER));
+    verify(resolver, times(1)).resolvePrincipals(eq(SAMPLE_USER), eq(SAMPLE_DIRECTORY));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestRequestContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestRequestContext.java
@@ -21,7 +21,6 @@
 
 package com.google.solutions.jitaccess.web;
 
-import com.google.solutions.jitaccess.catalog.Subjects;
 import com.google.solutions.jitaccess.catalog.auth.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
- Add `class:internalUsers`, `class:externalUsers` principal identifiers
- Add principal identifier to subject depending on their directory (derived from `hd` assertion)