### PR TITLE
b/365165937 Rename UserClassId to ClassPrincipalSet

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/ClassPrincipalSet.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/ClassPrincipalSet.java
@@ -28,9 +28,9 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Pseudo-principal identifier for a class of users.
+ * Principal set that matches a class of users.
  */
-public class UserClassId implements PrincipalId, Comparable<UserClassId> {
+public class ClassPrincipalSet implements PrincipalId, Comparable<ClassPrincipalSet> {
   public static final String TYPE = "class";
   private static final String TYPE_PREFIX = TYPE + ":";
 
@@ -40,7 +40,7 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
    * Principal identifier that identifies all users that
    * have been authorized by IAP.
    */
-  public static final @NotNull UserClassId IAP_USERS = new UserClassId("iapUsers");
+  public static final @NotNull ClassPrincipalSet IAP_USERS = new ClassPrincipalSet("iapUsers");
 
   /**
    * Principal identifier that identifies all users that
@@ -50,29 +50,29 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
    * Consumer accounts and service accounts are not considered
    * internal.
    */
-  public static final @NotNull UserClassId INTERNAL_USERS = new UserClassId("internalUsers");
+  public static final @NotNull ClassPrincipalSet INTERNAL_USERS = new ClassPrincipalSet("internalUsers");
 
   /**
    * Principal identifier that identifies all users that
    * do not belong to the internal Cloud Identity/Workspace account,
    * including consumer accounts and service accounts.
    */
-  public static final @NotNull UserClassId EXTERNAL_USERS = new UserClassId("externalUsers");
+  public static final @NotNull ClassPrincipalSet EXTERNAL_USERS = new ClassPrincipalSet("externalUsers");
 
-  private static final Map<String, UserClassId> PARSE_MAP = Map.of(
+  private static final Map<String, ClassPrincipalSet> PARSE_MAP = Map.of(
     IAP_USERS.toString().toLowerCase(), IAP_USERS,
     INTERNAL_USERS.toString().toLowerCase(), INTERNAL_USERS,
     EXTERNAL_USERS.toString().toLowerCase(), EXTERNAL_USERS);
 
   @SuppressWarnings("SameParameterValue")
-  private UserClassId(@NotNull String value) {
+  private ClassPrincipalSet(@NotNull String value) {
     this.value = value;
   }
 
   /**
    * Parse a user ID that uses prefixed syntax.
    */
-  public static Optional<UserClassId> parse(@Nullable String s) {
+  public static Optional<ClassPrincipalSet> parse(@Nullable String s) {
     if (s == null || s.isBlank()) {
       return Optional.empty();
     }
@@ -114,12 +114,12 @@ public class UserClassId implements PrincipalId, Comparable<UserClassId> {
       return false;
     }
 
-    UserClassId id = (UserClassId) o;
+    ClassPrincipalSet id = (ClassPrincipalSet) o;
     return this.value.equals(id.value);
   }
 
   @Override
-  public int compareTo(@NotNull UserClassId o) {
+  public int compareTo(@NotNull ClassPrincipalSet o) {
     return this.value.compareTo(o.value());
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
@@ -240,7 +240,7 @@ public class SubjectResolver {
   ) throws AccessException, IOException {
 
     var allPrincipals = new HashSet<Principal>();
-    allPrincipals.add(new Principal(UserClassId.IAP_USERS));
+    allPrincipals.add(new Principal(ClassPrincipalSet.IAP_USERS));
     allPrincipals.add(new Principal(user));
     allPrincipals.addAll(resolveGroupPrincipals(user));
 
@@ -255,13 +255,13 @@ public class SubjectResolver {
       //
       // This user belongs to the internal directory.
       //
-      allPrincipals.add(new Principal(UserClassId.INTERNAL_USERS));
+      allPrincipals.add(new Principal(ClassPrincipalSet.INTERNAL_USERS));
     }
     else {
       //
       // This user does not belong to the internal directory.
       //
-      allPrincipals.add(new Principal(UserClassId.EXTERNAL_USERS));
+      allPrincipals.add(new Principal(ClassPrincipalSet.EXTERNAL_USERS));
     }
 
     return allPrincipals;

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/legacy/LegacyPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/legacy/LegacyPolicy.java
@@ -136,7 +136,7 @@ public class LegacyPolicy extends EnvironmentPolicy {
             //
             // Allow all users to VIEW.
             //
-            Stream.of(new AccessControlList.AllowedEntry(UserClassId.IAP_USERS, PolicyPermission.VIEW.toMask())))
+            Stream.of(new AccessControlList.AllowedEntry(ClassPrincipalSet.IAP_USERS, PolicyPermission.VIEW.toMask())))
           .toList()
       ),
       Map.of(

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/EnvironmentPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/EnvironmentPolicy.java
@@ -22,7 +22,7 @@
 package com.google.solutions.jitaccess.catalog.policy;
 
 import com.google.common.base.Preconditions;
-import com.google.solutions.jitaccess.catalog.auth.UserClassId;
+import com.google.solutions.jitaccess.catalog.auth.ClassPrincipalSet;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -42,7 +42,7 @@ public class EnvironmentPolicy extends AbstractPolicy {
    * Default ACL for environments.
    */
   static final AccessControlList DEFAULT_ACCESS_CONTROL_LIST = new AccessControlList(
-    List.of(new AccessControlList.AllowedEntry(UserClassId.IAP_USERS, PolicyPermission.VIEW.toMask())));
+    List.of(new AccessControlList.AllowedEntry(ClassPrincipalSet.IAP_USERS, PolicyPermission.VIEW.toMask())));
 
   private final @NotNull Map<String, SystemPolicy> systems = new TreeMap<>();
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
@@ -32,7 +32,7 @@ import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.apis.*;
 import com.google.solutions.jitaccess.catalog.auth.GroupId;
 import com.google.solutions.jitaccess.catalog.auth.PrincipalId;
-import com.google.solutions.jitaccess.catalog.auth.UserClassId;
+import com.google.solutions.jitaccess.catalog.auth.ClassPrincipalSet;
 import com.google.solutions.jitaccess.catalog.auth.EndUserId;
 import com.google.solutions.jitaccess.util.Coalesce;
 import com.google.solutions.jitaccess.util.Exceptions;
@@ -642,7 +642,7 @@ public class PolicyDocument {
             return Optional.<PrincipalId>empty()
               .or(() -> EndUserId.parse(s))
               .or(() -> GroupId.parse(s))
-              .or(() -> UserClassId.parse(s))
+              .or(() -> ClassPrincipalSet.parse(s))
               .orElse(null);
           }
           catch (IllegalArgumentException e) {

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/Subjects.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/Subjects.java
@@ -38,7 +38,7 @@ public class Subjects {
   ) {
     var defaultPrincipals = Stream.of(
       new Principal(user),
-      new Principal(UserClassId.IAP_USERS));
+      new Principal(ClassPrincipalSet.IAP_USERS));
 
     var subject = Mockito.mock(Subject.class);
     when(subject.user()).thenReturn(user);

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestClassPrincipalSet.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestClassPrincipalSet.java
@@ -21,45 +21,32 @@
 
 package com.google.solutions.jitaccess.catalog.auth;
 
+import com.google.solutions.jitaccess.TestRecord;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestUserClassId {
+public class TestClassPrincipalSet extends TestRecord<ClassPrincipalSet> {
+  @Override
+  protected @NotNull ClassPrincipalSet createInstance() {
+    return ClassPrincipalSet.IAP_USERS;
+  }
+
+  @Override
+  protected @NotNull ClassPrincipalSet createDifferentInstance() {
+    return ClassPrincipalSet.INTERNAL_USERS;
+  }
+
   // -------------------------------------------------------------------------
   // toString.
   // -------------------------------------------------------------------------
 
   @Test
   public void toString_returnsPrefixedValue() {
-    assertEquals("class:iapUsers", UserClassId.IAP_USERS.toString());
-  }
-
-  // -------------------------------------------------------------------------
-  // Equality.
-  // -------------------------------------------------------------------------
-
-  @Test
-  public void equals_whenObjectAreEquivalent() {
-    UserClassId id1 = UserClassId.IAP_USERS;
-    UserClassId id2 = UserClassId.IAP_USERS;
-
-    assertTrue(id1.equals(id2));
-    assertEquals(id1.hashCode(), id2.hashCode());
-    assertEquals(0, id1.compareTo(id2));
-  }
-
-  @Test
-  public void equals_whenObjectIsNull() {
-    assertFalse(UserClassId.IAP_USERS.equals(null));
-  }
-
-  @Test
-  public void equals_whenObjectIsDifferentType() {
-    assertFalse(UserClassId.IAP_USERS.equals(""));
-    assertFalse(UserClassId.IAP_USERS.equals(new EndUserId("user@example.com")));
+    assertEquals("class:iapUsers", ClassPrincipalSet.IAP_USERS.toString());
   }
 
   // -------------------------------------------------------------------------
@@ -68,12 +55,12 @@ public class TestUserClassId {
 
   @Test
   public void value() {
-    assertEquals("iapUsers", UserClassId.IAP_USERS.value());
+    assertEquals("iapUsers", ClassPrincipalSet.IAP_USERS.value());
   }
 
   @Test
   public void iamPrincipalId() {
-    assertFalse(((Object)UserClassId.IAP_USERS) instanceof IamPrincipalId);
+    assertFalse(((Object) ClassPrincipalSet.IAP_USERS) instanceof IamPrincipalId);
   }
 
   // -------------------------------------------------------------------------
@@ -89,8 +76,8 @@ public class TestUserClassId {
     "class"
   })
   public void parse_whenInvalid(String s) {
-    assertFalse(UserClassId.parse(null).isPresent());
-    assertFalse(UserClassId.parse(s).isPresent());
+    assertFalse(ClassPrincipalSet.parse(null).isPresent());
+    assertFalse(ClassPrincipalSet.parse(s).isPresent());
   }
 
   @ParameterizedTest
@@ -99,7 +86,7 @@ public class TestUserClassId {
     "class:IAPUSERS  "
   })
   public void parse_iapUsers(String s) {
-    assertEquals(UserClassId.IAP_USERS, UserClassId.parse(s).get());
+    assertEquals(ClassPrincipalSet.IAP_USERS, ClassPrincipalSet.parse(s).get());
   }
 
   @ParameterizedTest
@@ -108,7 +95,7 @@ public class TestUserClassId {
     "class:INTERNALUSERS  "
   })
   public void parse_internalUsers(String s) {
-    assertEquals(UserClassId.INTERNAL_USERS, UserClassId.parse(s).get());
+    assertEquals(ClassPrincipalSet.INTERNAL_USERS, ClassPrincipalSet.parse(s).get());
   }
 
   @ParameterizedTest
@@ -117,6 +104,6 @@ public class TestUserClassId {
     "class:EXTERNALUSERS  "
   })
   public void parse_externalUsers(String s) {
-    assertEquals(UserClassId.EXTERNAL_USERS, UserClassId.parse(s).get());
+    assertEquals(ClassPrincipalSet.EXTERNAL_USERS, ClassPrincipalSet.parse(s).get());
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
@@ -23,19 +23,15 @@ package com.google.solutions.jitaccess.catalog.auth;
 
 import com.google.api.services.cloudidentity.v1.model.*;
 import com.google.solutions.jitaccess.apis.Domain;
-import com.google.solutions.jitaccess.apis.clients.AccessException;
 import com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient;
 import com.google.solutions.jitaccess.apis.clients.ResourceNotFoundException;
 import com.google.solutions.jitaccess.catalog.EventIds;
 import com.google.solutions.jitaccess.catalog.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
@@ -217,8 +213,8 @@ public class TestSubjectResolver {
       .collect(Collectors.toSet());
 
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
-    assertTrue(principals.contains(UserClassId.IAP_USERS), "All");
-    assertTrue(principals.contains(UserClassId.INTERNAL_USERS), "Internal");
+    assertTrue(principals.contains(ClassPrincipalSet.IAP_USERS), "All");
+    assertTrue(principals.contains(ClassPrincipalSet.INTERNAL_USERS), "Internal");
   }
 
   @Test
@@ -242,8 +238,8 @@ public class TestSubjectResolver {
       .collect(Collectors.toSet());
 
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
-    assertTrue(principals.contains(UserClassId.IAP_USERS), "All");
-    assertTrue(principals.contains(UserClassId.EXTERNAL_USERS), "External");
+    assertTrue(principals.contains(ClassPrincipalSet.IAP_USERS), "All");
+    assertTrue(principals.contains(ClassPrincipalSet.EXTERNAL_USERS), "External");
   }
 
   @Test
@@ -267,7 +263,7 @@ public class TestSubjectResolver {
       .collect(Collectors.toSet());
 
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
-    assertTrue(principals.contains(UserClassId.IAP_USERS), "All");
-    assertTrue(principals.contains(UserClassId.EXTERNAL_USERS), "External");
+    assertTrue(principals.contains(ClassPrincipalSet.IAP_USERS), "All");
+    assertTrue(principals.contains(ClassPrincipalSet.EXTERNAL_USERS), "External");
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/legacy/TestLegacyPolicy.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/legacy/TestLegacyPolicy.java
@@ -27,7 +27,7 @@ import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import com.google.solutions.jitaccess.apis.IamRole;
 import com.google.solutions.jitaccess.apis.ProjectId;
 import com.google.solutions.jitaccess.catalog.auth.GroupId;
-import com.google.solutions.jitaccess.catalog.auth.UserClassId;
+import com.google.solutions.jitaccess.catalog.auth.ClassPrincipalSet;
 import com.google.solutions.jitaccess.catalog.auth.EndUserId;
 import com.google.solutions.jitaccess.catalog.policy.*;
 import org.junit.jupiter.api.Nested;
@@ -60,7 +60,7 @@ public class TestLegacyPolicy {
 
     var aces = List.copyOf(policy.effectiveAccessControlList().entries());
     assertEquals(1, aces.size());
-    assertEquals(UserClassId.IAP_USERS, aces.get(0).principal);
+    assertEquals(ClassPrincipalSet.IAP_USERS, aces.get(0).principal);
     assertEquals(PolicyPermission.VIEW.toMask(), aces.get(0).accessRights);
   }
 
@@ -95,7 +95,7 @@ public class TestLegacyPolicy {
     assertEquals(new EndUserId("admin-1@example.com"), aces.get(0).principal);
     assertEquals(PolicyPermission.EXPORT.toMask(), aces.get(0).accessRights);
 
-    assertEquals(UserClassId.IAP_USERS, aces.get(1).principal);
+    assertEquals(ClassPrincipalSet.IAP_USERS, aces.get(1).principal);
     assertEquals(PolicyPermission.VIEW.toMask(), aces.get(1).accessRights);
   }
 
@@ -130,7 +130,7 @@ public class TestLegacyPolicy {
     assertEquals(new EndUserId("admin-1@example.com"), aces.get(1).principal);
     assertEquals(PolicyPermission.RECONCILE.toMask(), aces.get(1).accessRights);
 
-    assertEquals(UserClassId.IAP_USERS, aces.get(2).principal);
+    assertEquals(ClassPrincipalSet.IAP_USERS, aces.get(2).principal);
     assertEquals(PolicyPermission.VIEW.toMask(), aces.get(2).accessRights);
   }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
@@ -26,7 +26,7 @@ import com.google.solutions.jitaccess.apis.FolderId;
 import com.google.solutions.jitaccess.apis.IamRole;
 import com.google.solutions.jitaccess.apis.OrganizationId;
 import com.google.solutions.jitaccess.apis.ProjectId;
-import com.google.solutions.jitaccess.catalog.auth.UserClassId;
+import com.google.solutions.jitaccess.catalog.auth.ClassPrincipalSet;
 import com.google.solutions.jitaccess.catalog.auth.EndUserId;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Nested;
@@ -335,7 +335,7 @@ public class TestPolicyDocument {
 
       var aces = List.copyOf(policy.get().accessControlList().get().entries());
       assertEquals(1, aces.size());
-      assertEquals(UserClassId.IAP_USERS, aces.get(0).principal);
+      assertEquals(ClassPrincipalSet.IAP_USERS, aces.get(0).principal);
       assertEquals(PolicyPermission.VIEW.toMask(), aces.get(0).accessRights);
     }
 


### PR DESCRIPTION
Rename `UserClassId` to `ClassPrincipalSet` to better align with IAM naming conventions