### PR TITLE
b/365165937 Add principal set for users from a Cloud Identity domain

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CloudIdentityDirectoryPrincipalSet.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CloudIdentityDirectoryPrincipalSet.java
@@ -21,6 +21,7 @@
 
 package com.google.solutions.jitaccess.catalog.auth;
 
+import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.apis.Domain;
 import com.google.solutions.jitaccess.util.NullaryOptional;
 import org.jetbrains.annotations.NotNull;
@@ -44,6 +45,13 @@ public class CloudIdentityDirectoryPrincipalSet implements PrincipalId {
 
   CloudIdentityDirectoryPrincipalSet(@NotNull String primaryDomain) {
     this.primaryDomain = primaryDomain;
+  }
+
+  CloudIdentityDirectoryPrincipalSet(@NotNull Directory directory) {
+    Preconditions.checkArgument(directory.type() == Directory.Type.CLOUD_IDENTITY);
+    Preconditions.checkArgument(directory.hostedDomain().type() == Domain.Type.PRIMARY);
+
+    this.primaryDomain = directory.hostedDomain().name();
   }
 
   @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CloudIdentityDirectoryPrincipalSet.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/CloudIdentityDirectoryPrincipalSet.java
@@ -1,0 +1,113 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.catalog.auth;
+
+import com.google.solutions.jitaccess.apis.Domain;
+import com.google.solutions.jitaccess.util.NullaryOptional;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Principal set that matches all users of a
+ * Cloud Identity/Workspace account, equivalent to the
+ * <code>domain:</code> principal identifier used by IAM.
+ */
+public class CloudIdentityDirectoryPrincipalSet implements PrincipalId {
+  private static final @NotNull Pattern PATTERN = Pattern.compile("^domain:([^:]+)$");
+
+  public static final String TYPE = "domain";
+  private static final String TYPE_PREFIX = TYPE + ":";
+
+  private final @NotNull String primaryDomain;
+
+  CloudIdentityDirectoryPrincipalSet(@NotNull String primaryDomain) {
+    this.primaryDomain = primaryDomain;
+  }
+
+  @Override
+  public String toString() {
+    return TYPE_PREFIX + this.primaryDomain;
+  }
+
+  /**
+   * Get the (primary) domain identified by this principal set.
+   */
+  public @NotNull Domain domain() {
+    return new Domain(this.primaryDomain, Domain.Type.PRIMARY);
+  }
+
+  /**
+   * Parse a group ID that uses the syntax <code>domain:PRIMARY_DOMAIN</code>.
+   */
+  public static Optional<CloudIdentityDirectoryPrincipalSet> parse(@Nullable String s) {
+    if (s == null || s.isBlank()) {
+      return Optional.empty();
+    }
+
+    s = s.trim();
+
+    var matcher = PATTERN.matcher(s.trim().toLowerCase());
+    return NullaryOptional
+      .ifTrue(matcher.matches())
+      .map(() -> new CloudIdentityDirectoryPrincipalSet(matcher.group(1).trim()));
+  }
+
+  // -------------------------------------------------------------------------
+  // Equality.
+  // -------------------------------------------------------------------------
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CloudIdentityDirectoryPrincipalSet set = (CloudIdentityDirectoryPrincipalSet) o;
+    return this.primaryDomain.equals(set.primaryDomain);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.primaryDomain.hashCode();
+  }
+
+  // -------------------------------------------------------------------------
+  // PrincipalId.
+  // -------------------------------------------------------------------------
+
+  @Override
+  public @NotNull String type() {
+    return TYPE;
+  }
+
+  @Override
+  public @NotNull String value() {
+    return this.primaryDomain;
+  }
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/auth/SubjectResolver.java
@@ -264,6 +264,13 @@ public class SubjectResolver {
       allPrincipals.add(new Principal(ClassPrincipalSet.EXTERNAL_USERS));
     }
 
+    //
+    // Add a domain:DOMAIN principal if this is a managed user.
+    //
+    if (directory.type() == Directory.Type.CLOUD_IDENTITY) {
+      allPrincipals.add(new Principal(new CloudIdentityDirectoryPrincipalSet(directory)));
+    }
+
     return allPrincipals;
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
@@ -30,10 +30,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.base.Strings;
 import com.google.solutions.jitaccess.apis.*;
-import com.google.solutions.jitaccess.catalog.auth.GroupId;
-import com.google.solutions.jitaccess.catalog.auth.PrincipalId;
-import com.google.solutions.jitaccess.catalog.auth.ClassPrincipalSet;
-import com.google.solutions.jitaccess.catalog.auth.EndUserId;
+import com.google.solutions.jitaccess.catalog.auth.*;
 import com.google.solutions.jitaccess.util.Coalesce;
 import com.google.solutions.jitaccess.util.Exceptions;
 import com.google.solutions.jitaccess.util.MoreStrings;
@@ -643,6 +640,7 @@ public class PolicyDocument {
               .or(() -> EndUserId.parse(s))
               .or(() -> GroupId.parse(s))
               .or(() -> ClassPrincipalSet.parse(s))
+              .or(() -> CloudIdentityDirectoryPrincipalSet.parse(s))
               .orElse(null);
           }
           catch (IllegalArgumentException e) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/RequireIapPrincipalFilter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/RequireIapPrincipalFilter.java
@@ -129,7 +129,7 @@ public class RequireIapPrincipalFilter implements ContainerRequestFilter {
 
     this.requestContext.authenticate(
       new EndUserId(debugPrincipalName),
-      new Directory("DEBUG"),
+      Directory.PROJECT,
       IapDevice.UNKNOWN);
   }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCloudIdentityDirectoryPrincipalSet.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCloudIdentityDirectoryPrincipalSet.java
@@ -28,8 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCloudIdentityDirectoryPrincipalSet extends TestRecord<CloudIdentityDirectoryPrincipalSet> {
   @Override
@@ -40,6 +39,20 @@ public class TestCloudIdentityDirectoryPrincipalSet extends TestRecord<CloudIden
   @Override
   protected @NotNull CloudIdentityDirectoryPrincipalSet createDifferentInstance() {
     return new CloudIdentityDirectoryPrincipalSet("example.org");
+  }
+
+  // -------------------------------------------------------------------------
+  // Constructor.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void constructor_whenWrongDirectoryType() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new CloudIdentityDirectoryPrincipalSet(Directory.CONSUMER));
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new CloudIdentityDirectoryPrincipalSet(Directory.PROJECT));
   }
 
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCloudIdentityDirectoryPrincipalSet.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestCloudIdentityDirectoryPrincipalSet.java
@@ -1,0 +1,109 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.google.solutions.jitaccess.catalog.auth;
+
+import com.google.solutions.jitaccess.TestRecord;
+import com.google.solutions.jitaccess.apis.Domain;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TestCloudIdentityDirectoryPrincipalSet extends TestRecord<CloudIdentityDirectoryPrincipalSet> {
+  @Override
+  protected @NotNull CloudIdentityDirectoryPrincipalSet createInstance() {
+    return new CloudIdentityDirectoryPrincipalSet("example.com");
+  }
+
+  @Override
+  protected @NotNull CloudIdentityDirectoryPrincipalSet createDifferentInstance() {
+    return new CloudIdentityDirectoryPrincipalSet("example.org");
+  }
+
+  // -------------------------------------------------------------------------
+  // toString.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void toString_returnsPrefixedValue() {
+    assertEquals(
+      "domain:example.com",
+      new CloudIdentityDirectoryPrincipalSet("example.com").toString());
+  }
+
+  // -------------------------------------------------------------------------
+  // domain.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void domain() {
+    assertEquals(
+      new Domain("example.com", Domain.Type.PRIMARY),
+      new CloudIdentityDirectoryPrincipalSet("example.com").domain());
+    assertEquals(
+      Domain.Type.PRIMARY,
+      new CloudIdentityDirectoryPrincipalSet("example.com").domain().type());
+  }
+
+  // -------------------------------------------------------------------------
+  // PrincipalId.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void value() {
+    assertEquals(
+      "example.com",
+      new CloudIdentityDirectoryPrincipalSet("example.com").value());
+  }
+
+  // -------------------------------------------------------------------------
+  // parse.
+  // -------------------------------------------------------------------------
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "",
+    "domain",
+    "domain:  ",
+    "domain:domain:example.com  ",
+    "domain"
+  })
+  public void parse_whenInvalid(String s) {
+    assertFalse(CloudIdentityDirectoryPrincipalSet.parse(null).isPresent());
+    assertFalse(CloudIdentityDirectoryPrincipalSet.parse(s).isPresent());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    " domain:example.com ",
+    " domain:  example.com",
+    "domain:EXAMPLE.com  "
+  })
+  public void parse(String s) {
+    assertEquals(
+      new CloudIdentityDirectoryPrincipalSet("example.com"),
+      CloudIdentityDirectoryPrincipalSet.parse(s).get());
+  }
+}

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/auth/TestSubjectResolver.java
@@ -212,9 +212,11 @@ public class TestSubjectResolver {
       .map(p -> p.id())
       .collect(Collectors.toSet());
 
+    assertEquals(4, principals.size());
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
     assertTrue(principals.contains(ClassPrincipalSet.IAP_USERS), "All");
     assertTrue(principals.contains(ClassPrincipalSet.INTERNAL_USERS), "Internal");
+    assertTrue(principals.contains(new CloudIdentityDirectoryPrincipalSet(new Directory(SAMPLE_DOMAIN))));
   }
 
   @Test
@@ -237,9 +239,11 @@ public class TestSubjectResolver {
       .map(p -> p.id())
       .collect(Collectors.toSet());
 
+    assertEquals(4, principals.size());
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
     assertTrue(principals.contains(ClassPrincipalSet.IAP_USERS), "All");
     assertTrue(principals.contains(ClassPrincipalSet.EXTERNAL_USERS), "External");
+    assertTrue(principals.contains(new CloudIdentityDirectoryPrincipalSet(new Directory("other.tld"))));
   }
 
   @Test
@@ -262,6 +266,7 @@ public class TestSubjectResolver {
       .map(p -> p.id())
       .collect(Collectors.toSet());
 
+    assertEquals(3, principals.size());
     assertTrue(principals.contains(SAMPLE_USER), "user principal");
     assertTrue(principals.contains(ClassPrincipalSet.IAP_USERS), "All");
     assertTrue(principals.contains(ClassPrincipalSet.EXTERNAL_USERS), "External");

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
@@ -863,16 +863,22 @@ public class TestPolicyDocument {
         issues.issues().get(0).code());
     }
 
-    @Test
-    public void toPolicy() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "user:user@example.com",
+      "group:group@example.com",
+      "class:internalUsers",
+      "domain:example.com",
+    })
+    public void toPolicy(String principalId) {
       var element = new PolicyDocument.AccessControlEntryElement(
-        "user:" + SAMPLE_USER.email,
+        principalId,
         "JOIN",
         null);
 
       var issues = new PolicyDocument.IssueCollection();
       var policy = element.toPolicy(issues);
-      assertEquals(SAMPLE_USER, policy.get().principal);
+      assertEquals(principalId, policy.get().principal.toString());
       assertEquals(PolicyPermission.JOIN.toMask(), policy.get().accessRights);
     }
   }


### PR DESCRIPTION
Add `domain:` principal set to identify users from a Cloud Identity account