### PR TITLE
b/365420016 Refactor LazyCatalogSource

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -436,15 +436,18 @@ public class Application {
       }
     }
 
+    var options = new LazyCatalogSource.Options(
+      runtime.type() == ApplicationRuntime.Type.DEVELOPMENT
+        ? Duration.ofSeconds(20)
+        : configuration.environmentCacheTimeout,
+      produceHttpTransportOptions());
+
     return new LazyCatalogSource(
       configurations,
       groupMapping,
       groupsClient,
-      runtime.type() == ApplicationRuntime.Type.DEVELOPMENT
-        ? Duration.ofSeconds(20)
-        : configuration.environmentCacheTimeout,
       executor,
-      produceHttpTransportOptions(),
+      options,
       logger);
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -25,7 +25,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.solutions.jitaccess.ApplicationRuntime;
-import com.google.solutions.jitaccess.apis.StructuredLogger;
 import com.google.solutions.jitaccess.apis.clients.*;
 import com.google.solutions.jitaccess.catalog.Catalog;
 import com.google.solutions.jitaccess.catalog.JitGroupContext;
@@ -47,7 +46,6 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Produces CDI beans to initialize application components.

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
@@ -51,7 +51,6 @@ import java.util.function.Supplier;
 class EnvironmentConfiguration implements PolicyHeader {
   private static final String DEFAULT_DESCRIPTION = "JIT Groups environment";
 
-
   private static final String OOBE_POLICY_NAME = "example";
   private static final String OOBE_POLICY_DESCRIPTION = "Example policy";
   private static final String OOBE_POLICY_PATH = "oobe/policy.yaml";
@@ -87,7 +86,7 @@ class EnvironmentConfiguration implements PolicyHeader {
     return this.resourceCredentials;
   }
 
-  public EnvironmentPolicy loadPolicy() {
+  public EnvironmentPolicy loadPolicy() { // TODO: Return PolicyDocument
     return this.loadPolicy.get();
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
@@ -82,11 +82,11 @@ class EnvironmentConfiguration implements PolicyHeader {
     return this.description;
   }
 
-  public GoogleCredentials resourceCredentials() {
+  GoogleCredentials resourceCredentials() {
     return this.resourceCredentials;
   }
 
-  public EnvironmentPolicy loadPolicy() { // TODO: Return PolicyDocument
+  EnvironmentPolicy loadPolicy() { // TODO: Return PolicyDocument
     return this.loadPolicy.get();
   }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestLazyCatalogSource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestLazyCatalogSource.java
@@ -25,7 +25,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient;
 import com.google.solutions.jitaccess.apis.clients.HttpTransport;
-import com.google.solutions.jitaccess.apis.clients.ResourceManagerClient;
 import com.google.solutions.jitaccess.catalog.Catalog;
 import com.google.solutions.jitaccess.apis.Logger;
 import com.google.solutions.jitaccess.catalog.auth.GroupMapping;
@@ -40,7 +39,6 @@ import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executor;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,11 +48,8 @@ import static org.mockito.Mockito.verify;
 
 public class TestLazyCatalogSource {
   private static final Executor EXECUTOR = command -> command.run();
-
-  private record SampleEnvironment(
-    @NotNull String name,
-    @NotNull String description
-  ) implements PolicyHeader {}
+  private static final LazyCatalogSource.Options OPTIONS =
+    new LazyCatalogSource.Options(Duration.ZERO, HttpTransport.Options.DEFAULT);
 
   // -------------------------------------------------------------------------
   // environments.
@@ -76,9 +71,8 @@ public class TestLazyCatalogSource {
           () -> { throw new UnsupportedOperationException(); })),
       Mockito.mock(GroupMapping.class),
       Mockito.mock(CloudIdentityGroupsClient.class),
-      Duration.ZERO,
       EXECUTOR,
-      HttpTransport.Options.DEFAULT,
+      OPTIONS,
       Mockito.mock(Logger.class));
 
     assertEquals(2, loader.environmentPolicies().size());
@@ -110,9 +104,8 @@ public class TestLazyCatalogSource {
       List.of(),
       Mockito.mock(GroupMapping.class),
       Mockito.mock(CloudIdentityGroupsClient.class),
-      Duration.ZERO,
       EXECUTOR,
-      HttpTransport.Options.DEFAULT,
+      OPTIONS,
       logger);
 
     assertFalse(loader
@@ -138,9 +131,8 @@ public class TestLazyCatalogSource {
           () -> { throw new UnsupportedOperationException(); })),
       Mockito.mock(GroupMapping.class),
       Mockito.mock(CloudIdentityGroupsClient.class),
-      Duration.ZERO,
       EXECUTOR,
-      HttpTransport.Options.DEFAULT,
+      OPTIONS,
       logger);
 
     assertFalse(loader
@@ -166,9 +158,8 @@ public class TestLazyCatalogSource {
           () -> { throw new  UncheckedExecutionException(new FileNotFoundException()); })),
       Mockito.mock(GroupMapping.class),
       Mockito.mock(CloudIdentityGroupsClient.class),
-      Duration.ZERO,
       EXECUTOR,
-      HttpTransport.Options.DEFAULT,
+      OPTIONS,
       logger);
 
     assertFalse(loader
@@ -194,9 +185,8 @@ public class TestLazyCatalogSource {
           () -> new EnvironmentPolicy("env", "", new Policy.Metadata("mock", Instant.now())))),
       Mockito.mock(GroupMapping.class),
       Mockito.mock(CloudIdentityGroupsClient.class),
-      Duration.ZERO,
       EXECUTOR,
-      HttpTransport.Options.DEFAULT,
+      OPTIONS,
       logger);
 
     var environment = loader.provisioner(Mockito.mock(Catalog.class), "env");

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestLazyCatalogSource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestLazyCatalogSource.java
@@ -30,8 +30,6 @@ import com.google.solutions.jitaccess.apis.Logger;
 import com.google.solutions.jitaccess.catalog.auth.GroupMapping;
 import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
 import com.google.solutions.jitaccess.catalog.policy.Policy;
-import com.google.solutions.jitaccess.catalog.policy.PolicyHeader;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 


### PR DESCRIPTION
- Simplify initialization to use a list of `EnvironmentConfiguration` objects
- Reduce use of lambdas