### PR TITLE
b/365420016 Refactor Environment to use PolicyDocumentSource

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
@@ -103,7 +103,7 @@ public class PolicyDocument {
   /**
    * Parse a YAML-formatted document and validate its content.
    */
-  public static @NotNull PolicyDocument parse(
+  static @NotNull PolicyDocument parse(
     @NotNull PolicyDocumentSource source
   ) throws SyntaxException {
     var issues = new IssueCollection();

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocumentSource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocumentSource.java
@@ -32,18 +32,55 @@ import java.time.Instant;
 /**
  * Raw, unparsed source of a policy document.
  */
-public record PolicyDocumentSource(
-  @NotNull String yaml,
-  @NotNull Policy.Metadata metadata
-  ) {
+public abstract class PolicyDocumentSource {
+  /**
+   * Get YAML-formatted source.
+   */
+  public abstract @NotNull String yaml();
+
+  /**
+   * Get metadata about the origin of the policy.
+   */
+  public abstract @NotNull Policy.Metadata metadata();
+
+  /**
+   * Parse and validate source.
+   */
+  public abstract PolicyDocument parse() throws PolicyDocument.SyntaxException;
 
   /**
    * Create a policy document from an in-memory string.
    */
-  public static @NotNull PolicyDocumentSource fromMemory(
+  public static @NotNull PolicyDocumentSource fromString(
+    @NotNull String yaml,
+    @NotNull Policy.Metadata metadata
+  ) {
+    return new PolicyDocumentSource() {
+      @Override
+      public @NotNull String yaml() {
+        return yaml;
+      }
+
+      @Override
+      public @NotNull Policy.Metadata metadata() {
+        return metadata;
+      }
+
+      @Override
+      public PolicyDocument parse() throws PolicyDocument.SyntaxException {
+        return PolicyDocument.parse(this);
+      }
+    };
+  }
+
+  /**
+   * Create a policy document from an in-memory string
+   * using default metadata.
+   */
+  public static @NotNull PolicyDocumentSource fromString(
     @NotNull String yaml
   ) {
-    return new PolicyDocumentSource(
+    return fromString(
       yaml,
       new Policy.Metadata(
         "memory",
@@ -61,7 +98,7 @@ public record PolicyDocumentSource(
         String.format("The file '%s' does not exist", file.getAbsolutePath()));
     }
 
-    return new PolicyDocumentSource(
+    return fromString(
       Files.readString(file.toPath()),
       new Policy.Metadata(
         file.getName(),
@@ -69,14 +106,31 @@ public record PolicyDocumentSource(
   }
 
   /**
-   * Parse and validate source.
+   * Reconstruct a source from a document.
    */
-  public PolicyDocument parse() throws PolicyDocument.SyntaxException {
-    return PolicyDocument.parse(this);
+  public static @NotNull PolicyDocumentSource fromPolicyDocument(
+    @NotNull PolicyDocument document
+  ) {
+    return new PolicyDocumentSource() {
+      @Override
+      public @NotNull String yaml() {
+        return document.toString();
+      }
+
+      @Override
+      public @NotNull Policy.Metadata metadata() {
+        return document.policy().metadata();
+      }
+
+      @Override
+      public PolicyDocument parse() {
+        return document;
+      }
+    };
   }
 
   @Override
   public String toString() {
-    return this.yaml;
+    return this.yaml();
   }
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocumentSource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocumentSource.java
@@ -68,6 +68,13 @@ public record PolicyDocumentSource(
         Instant.ofEpochMilli(file.lastModified())));
   }
 
+  /**
+   * Parse and validate source.
+   */
+  public PolicyDocument parse() throws PolicyDocument.SyntaxException {
+    return PolicyDocument.parse(this);
+  }
+
   @Override
   public String toString() {
     return this.yaml;

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocumentSource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocumentSource.java
@@ -106,11 +106,13 @@ public abstract class PolicyDocumentSource {
   }
 
   /**
-   * Reconstruct a source from a document.
+   * Reconstruct source for a policy.
    */
-  public static @NotNull PolicyDocumentSource fromPolicyDocument(
-    @NotNull PolicyDocument document
+  public static @NotNull PolicyDocumentSource fromPolicy(
+    @NotNull EnvironmentPolicy policy
   ) {
+    var document = new PolicyDocument(policy);
+
     return new PolicyDocumentSource() {
       @Override
       public @NotNull String yaml() {

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Environment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Environment.java
@@ -51,7 +51,9 @@ public abstract class Environment {
     // might be slow.
     //
     this.policy = Lazy
-      .initializeOpportunistically(this::loadPolicy)
+      .initializeOpportunistically(() -> loadPolicy()
+        .parse()
+        .policy())
       .reinitializeAfter(policyCacheDuration);
   }
 
@@ -84,7 +86,7 @@ public abstract class Environment {
   }
 
   /**
-   * Load policy from file or backing store.
+   * Load the raw, unparsed policy from file or backing store.
    */
-  protected abstract EnvironmentPolicy loadPolicy();
+  protected abstract PolicyDocumentSource loadPolicy();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -34,6 +34,7 @@ import com.google.solutions.jitaccess.catalog.Proposal;
 import com.google.solutions.jitaccess.catalog.legacy.LegacyPolicy;
 import com.google.solutions.jitaccess.catalog.legacy.LegacyPolicyLoader;
 import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
+import com.google.solutions.jitaccess.catalog.policy.PolicyDocumentSource;
 import com.google.solutions.jitaccess.web.proposal.*;
 import com.google.solutions.jitaccess.web.rest.UserResource;
 import jakarta.enterprise.context.RequestScoped;
@@ -411,15 +412,15 @@ public class Application {
           runtime.applicationCredentials() // Use app service account, as in 1.x
         ) {
           @Override
-          EnvironmentPolicy loadPolicy() {
+          PolicyDocumentSource loadPolicy() {
             try {
-              return legacyLoader.load(
+              return PolicyDocumentSource.fromPolicy(legacyLoader.load(
                 configuration.legacyProjectsQuery,
                 configuration.legacyScope.get(),
                 configuration.legacyActivationTimeout,
                 configuration.legacyJustificationPattern,
                 configuration.legacyJustificationHint,
-                logger);
+                logger));
             }
             catch (Exception e) {
               throw new UncheckedExecutionException(e);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
@@ -123,8 +123,8 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
       @Override
       EnvironmentPolicy loadPolicy() {
         try {
-          return PolicyDocument
-            .parse(PolicyDocumentSource.fromFile(file))
+          return PolicyDocumentSource.fromFile(file)
+            .parse()
             .policy();
         }
         catch (Exception e) {
@@ -176,8 +176,8 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
           }
 
           var policy = new String(stream.readAllBytes());
-          return PolicyDocument
-            .parse(new PolicyDocumentSource(policy, metadata))
+          return new PolicyDocumentSource(policy, metadata)
+            .parse()
             .policy();
         }
         catch (Exception e) {
@@ -287,10 +287,10 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
             null,
             environmentName);
 
-          return PolicyDocument.parse(
-            new PolicyDocumentSource(
+          return new PolicyDocumentSource(
               secretClient.accessSecret(secretPath),
-              metadata))
+              metadata)
+            .parse()
             .policy();
         }
         catch (Exception e) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
@@ -82,7 +82,7 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
   /**
    * Load policy from file or backend.
    */
-  abstract EnvironmentPolicy loadPolicy();
+  abstract PolicyDocumentSource loadPolicy();
 
   /**
    * Create configuration for a file-based policy.
@@ -120,11 +120,9 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
       applicationCredentials
     ) {
       @Override
-      EnvironmentPolicy loadPolicy() {
+      PolicyDocumentSource loadPolicy() {
         try {
-          return PolicyDocumentSource.fromFile(file)
-            .parse()
-            .policy();
+          return PolicyDocumentSource.fromFile(file);
         }
         catch (Exception e) {
           throw new UncheckedExecutionException(e);
@@ -166,7 +164,7 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
       applicationCredentials
     ) {
       @Override
-      EnvironmentPolicy loadPolicy() {
+      PolicyDocumentSource loadPolicy() {
         try (var stream = EnvironmentConfiguration.class
           .getClassLoader()
           .getResourceAsStream(resourcePath)) {
@@ -175,10 +173,7 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
           }
 
           var policy = new String(stream.readAllBytes());
-          return PolicyDocumentSource
-            .fromString(policy, metadata)
-            .parse()
-            .policy();
+          return PolicyDocumentSource.fromString(policy, metadata);
         }
         catch (Exception e) {
           throw new UncheckedExecutionException(e);
@@ -249,7 +244,7 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
       environmentCredentials
     ) {
       @Override
-      EnvironmentPolicy loadPolicy() {
+      PolicyDocumentSource loadPolicy() {
         //
         // If we lack impersonation permissions, ImpersonatedCredentials
         // will keep retrying until the call timeout expires. The effect
@@ -287,12 +282,9 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
             null,
             environmentName);
 
-          return PolicyDocumentSource
-            .fromString(
-              secretClient.accessSecret(secretPath),
-              metadata)
-            .parse()
-            .policy();
+          return PolicyDocumentSource.fromString(
+            secretClient.accessSecret(secretPath),
+            metadata);
         }
         catch (Exception e) {
           throw new UncheckedExecutionException(e);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentConfiguration.java
@@ -40,7 +40,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
 import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Configuration for an environment.
@@ -176,7 +175,8 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
           }
 
           var policy = new String(stream.readAllBytes());
-          return new PolicyDocumentSource(policy, metadata)
+          return PolicyDocumentSource
+            .fromString(policy, metadata)
             .parse()
             .policy();
         }
@@ -287,7 +287,8 @@ abstract class EnvironmentConfiguration implements PolicyHeader {
             null,
             environmentName);
 
-          return new PolicyDocumentSource(
+          return PolicyDocumentSource
+            .fromString(
               secretClient.accessSecret(secretPath),
               metadata)
             .parse()

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentRegistry.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentRegistry.java
@@ -26,6 +26,7 @@ import com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient;
 import com.google.solutions.jitaccess.apis.clients.HttpTransport;
 import com.google.solutions.jitaccess.apis.clients.ResourceManagerClient;
 import com.google.solutions.jitaccess.auth.GroupMapping;
+import com.google.solutions.jitaccess.catalog.policy.PolicyDocumentSource;
 import com.google.solutions.jitaccess.catalog.provisioning.Provisioner;
 import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
 import com.google.solutions.jitaccess.catalog.provisioning.Environment;
@@ -77,7 +78,7 @@ class EnvironmentRegistry {
           options.cacheDuration()
         ) {
           @Override
-          protected EnvironmentPolicy loadPolicy() {
+          protected PolicyDocumentSource loadPolicy() {
             return cfg.loadPolicy();
           }
         };

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/PolicyResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/PolicyResource.java
@@ -72,7 +72,7 @@ public class PolicyResource {
       // NB. It's possible that the user is validating that doesn't
       //     explicitly specify a name (because it's implied).
       //
-      var documentSource = new PolicyDocumentSource(
+      var documentSource = PolicyDocumentSource.fromString(
         source,
         new Policy.Metadata(
           "user-provided",

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/PolicyResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/PolicyResource.java
@@ -72,14 +72,15 @@ public class PolicyResource {
       // NB. It's possible that the user is validating that doesn't
       //     explicitly specify a name (because it's implied).
       //
-      document = PolicyDocument.parse(
-        new PolicyDocumentSource(
-          source,
-          new Policy.Metadata(
-            "user-provided",
-            Instant.now(),
-            null,
-            "anonymous"))); // Accept policies without name.
+      var documentSource = new PolicyDocumentSource(
+        source,
+        new Policy.Metadata(
+          "user-provided",
+          Instant.now(),
+          null,
+          "anonymous")); // Accept policies without name.
+
+      document = documentSource.parse();
     }
     catch (PolicyDocument.SyntaxException e) {
       return LintingResultInfo.create(e);

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/Environments.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/Environments.java
@@ -24,6 +24,7 @@ package com.google.solutions.jitaccess.catalog;
 import com.google.solutions.jitaccess.auth.GroupId;
 import com.google.solutions.jitaccess.auth.JitGroupId;
 import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
+import com.google.solutions.jitaccess.catalog.policy.PolicyDocumentSource;
 import com.google.solutions.jitaccess.catalog.provisioning.Environment;
 import com.google.solutions.jitaccess.catalog.provisioning.Provisioner;
 import org.jetbrains.annotations.NotNull;
@@ -48,8 +49,8 @@ public class Environments {
 
         return (Environment)new Environment(p.name(), p.description(), provisioner, Duration.ofDays(1)) {
           @Override
-          protected EnvironmentPolicy loadPolicy() {
-            return p;
+          protected PolicyDocumentSource loadPolicy() {
+            return PolicyDocumentSource.fromPolicy(p);
           }
         };
       })

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocument.java
@@ -34,9 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -78,7 +75,7 @@ public class TestPolicyDocument {
   public void parse_whenYamlIsEmpty() {
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory("  ")));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString("  ")));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.FILE_UNKNOWN_PROPERTY,
@@ -89,7 +86,7 @@ public class TestPolicyDocument {
   public void parse_whenYamlMalformed() {
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory("}")));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString("}")));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.FILE_INVALID_SYNTAX,
@@ -102,7 +99,7 @@ public class TestPolicyDocument {
 
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml)));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString(yaml)));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.FILE_UNKNOWN_PROPERTY,
@@ -115,7 +112,7 @@ public class TestPolicyDocument {
 
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml)));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString(yaml)));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.FILE_INVALID_VERSION,
@@ -128,7 +125,7 @@ public class TestPolicyDocument {
 
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml)));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString(yaml)));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.FILE_INVALID_VERSION,
@@ -144,7 +141,7 @@ public class TestPolicyDocument {
 
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml)));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString(yaml)));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.ENVIRONMENT_MISSING,
@@ -160,7 +157,7 @@ public class TestPolicyDocument {
 
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml)));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString(yaml)));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.ENVIRONMENT_INVALID,
@@ -178,7 +175,7 @@ public class TestPolicyDocument {
 
     var e = assertThrows(
       PolicyDocument.SyntaxException.class,
-      () -> PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml)));
+      () -> PolicyDocument.parse(PolicyDocumentSource.fromString(yaml)));
     assertTrue(e.issues().get(0).severe());
     assertEquals(
       PolicyDocument.Issue.Code.SYSTEM_INVALID,
@@ -192,7 +189,7 @@ public class TestPolicyDocument {
         "environment: \n" +
         "  name: 'env-1'";
 
-    var doc = PolicyDocument.parse(PolicyDocumentSource.fromMemory(yaml));
+    var doc = PolicyDocument.parse(PolicyDocumentSource.fromString(yaml));
     assertEquals("env-1", doc.policy().name());
     assertEquals("memory", doc.policy().metadata().source());
     assertFalse(doc.policy().metadata().lastModified().isAfter(Instant.now()));

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocumentSource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestPolicyDocumentSource.java
@@ -40,7 +40,7 @@ public class TestPolicyDocumentSource {
   public void toString_returnsYaml() {
     assertEquals(
       "yaml",
-      new PolicyDocumentSource("yaml", new Policy.Metadata("test", Instant.now())).toString());
+      PolicyDocumentSource.fromString("yaml").toString());
   }
 
   //---------------------------------------------------------------------------
@@ -54,7 +54,7 @@ public class TestPolicyDocumentSource {
         "environment: \n" +
         "  name: 'env-1'";
 
-    var source = PolicyDocumentSource.fromMemory(yaml);
+    var source = PolicyDocumentSource.fromString(yaml);
     assertEquals(yaml, source.yaml());
     assertEquals("memory", source.metadata().source());
     assertFalse(source.metadata().lastModified().isAfter(Instant.now()));

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestEnvironmentConfiguration.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestEnvironmentConfiguration.java
@@ -130,7 +130,9 @@ public class TestEnvironmentConfiguration {
   public void inertExample() throws Exception {
     var policy = EnvironmentConfiguration
       .inertExample()
-      .loadPolicy();
+      .loadPolicy()
+      .parse()
+      .policy();
     assertNotEquals(0, policy.systems().size());
   }
 }


### PR DESCRIPTION
Refactor `Environment` so that it permits access to the to the raw `PolicyDocumentSource`.