### PR TITLE
b/365420016 Use original source when exporting the policy

### DIFF
--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/Catalog.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/Catalog.java
@@ -89,7 +89,7 @@ public class Catalog {
 
     return Optional.ofNullable(this.environments.get(name))
       .filter(env -> env.policy().isAccessAllowed(this.subject, EnumSet.of(PolicyPermission.VIEW)))
-      .map(env -> new EnvironmentContext(env.policy(), this.subject, env.provisioner()));
+      .map(env -> new EnvironmentContext(env, this.subject));
   }
 
   /**

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/EnvironmentContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/EnvironmentContext.java
@@ -27,6 +27,7 @@ import com.google.solutions.jitaccess.auth.Subject;
 import com.google.solutions.jitaccess.catalog.legacy.LegacyPolicy;
 import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
 import com.google.solutions.jitaccess.catalog.policy.PolicyDocument;
+import com.google.solutions.jitaccess.catalog.policy.PolicyDocumentSource;
 import com.google.solutions.jitaccess.catalog.policy.PolicyPermission;
 import com.google.solutions.jitaccess.common.NullaryOptional;
 import com.google.solutions.jitaccess.catalog.provisioning.Provisioner;
@@ -77,10 +78,10 @@ public class EnvironmentContext {
   /**
    * Export the environment policy. Requires EXPORT access.
    */
-  public Optional<PolicyDocument> export() {
+  public Optional<PolicyDocumentSource> export() {
     return NullaryOptional
       .ifTrue(canExport())
-      .map(() -> new PolicyDocument(this.policy));
+      .map(() -> PolicyDocumentSource.fromPolicy(this.policy));
   }
 
   /**

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/EnvironmentContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/EnvironmentContext.java
@@ -26,11 +26,10 @@ import com.google.solutions.jitaccess.apis.clients.AccessException;
 import com.google.solutions.jitaccess.auth.Subject;
 import com.google.solutions.jitaccess.catalog.legacy.LegacyPolicy;
 import com.google.solutions.jitaccess.catalog.policy.EnvironmentPolicy;
-import com.google.solutions.jitaccess.catalog.policy.PolicyDocument;
 import com.google.solutions.jitaccess.catalog.policy.PolicyDocumentSource;
 import com.google.solutions.jitaccess.catalog.policy.PolicyPermission;
+import com.google.solutions.jitaccess.catalog.provisioning.Environment;
 import com.google.solutions.jitaccess.common.NullaryOptional;
-import com.google.solutions.jitaccess.catalog.provisioning.Provisioner;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -43,25 +42,22 @@ import java.util.Optional;
  * Environment in the context of a specific subject.
  */
 public class EnvironmentContext {
-  private final @NotNull EnvironmentPolicy policy;
+  private final @NotNull Environment environment;
   private final @NotNull Subject subject;
-  private final @NotNull Provisioner provisioner;
 
   EnvironmentContext(
-    @NotNull EnvironmentPolicy policy,
-    @NotNull Subject subject,
-    @NotNull Provisioner provisioner
+    @NotNull Environment environment,
+    @NotNull Subject subject
   ) {
-    this.policy = policy;
+    this.environment = environment;
     this.subject = subject;
-    this.provisioner = provisioner;
   }
 
   /**
    * Get environment policy.
    */
   public @NotNull EnvironmentPolicy policy() {
-    return this.policy;
+    return this.environment.policy();
   }
 
   /**
@@ -70,9 +66,11 @@ public class EnvironmentContext {
    * Requires EXPORT access.
    */
   public boolean canExport() {
-    return this.policy.isAccessAllowed(
-      this.subject,
-      EnumSet.of(PolicyPermission.EXPORT));
+    return this.environment
+      .policy()
+      .isAccessAllowed(
+        this.subject,
+        EnumSet.of(PolicyPermission.EXPORT));
   }
 
   /**
@@ -81,7 +79,7 @@ public class EnvironmentContext {
   public Optional<PolicyDocumentSource> export() {
     return NullaryOptional
       .ifTrue(canExport())
-      .map(() -> PolicyDocumentSource.fromPolicy(this.policy));
+      .map(() -> PolicyDocumentSource.fromPolicy(this.environment.policy()));
   }
 
   /**
@@ -90,9 +88,11 @@ public class EnvironmentContext {
    * Requires RECONCILE access.
    */
   public boolean canReconcile() {
-    return this.policy.isAccessAllowed(
-      this.subject,
-      EnumSet.of(PolicyPermission.RECONCILE));
+    return this.environment
+      .policy()
+      .isAccessAllowed(
+        this.subject,
+        EnumSet.of(PolicyPermission.RECONCILE));
   }
 
   /**
@@ -109,10 +109,10 @@ public class EnvironmentContext {
     //
     // Enumerate groups in Cloud Identity and check then one-by-one.
     //
-    for (var groupId : this.provisioner.provisionedGroups()) {
-      var cloudIdentityGroupId = this.provisioner.cloudIdentityGroupId(groupId);
+    for (var groupId : this.environment.provisioner().provisionedGroups()) {
+      var cloudIdentityGroupId = this.environment.provisioner().cloudIdentityGroupId(groupId);
 
-      var policy =  this.policy
+      var policy =  this.environment.policy()
         .system(groupId.system())
         .flatMap(sys -> sys.group(groupId.name()));
       if (policy.isEmpty()) {
@@ -126,7 +126,7 @@ public class EnvironmentContext {
         // There's a policy for this group, so we can reconcile it.
         //
         try {
-          this.provisioner.reconcile(policy.get());
+          this.environment.provisioner().reconcile(policy.get());
           result.add(new JitGroupCompliance(groupId, cloudIdentityGroupId, policy.get(), null));
         }
         catch (AccessException | IOException e) {
@@ -139,7 +139,7 @@ public class EnvironmentContext {
     // If this is a legacy policy, add any incompatibilities that
     // prevented the mapping of legacy roles.
     //
-    if (this.policy instanceof LegacyPolicy legacyPolicy) {
+    if (this.environment.policy() instanceof LegacyPolicy legacyPolicy) {
       result.addAll(legacyPolicy.incompatibilities());
     }
 
@@ -150,11 +150,11 @@ public class EnvironmentContext {
    * List system policies for which the subject has VIEW access.
    */
   public @NotNull Collection<SystemContext> systems() {
-    return this.policy
+    return this.environment.policy()
       .systems()
       .stream()
       .filter(sys -> sys.isAccessAllowed(this.subject, EnumSet.of(PolicyPermission.VIEW)))
-      .map(sys -> new SystemContext(sys, this.subject, this.provisioner))
+      .map(sys -> new SystemContext(sys, this.subject, this.environment.provisioner()))
       .toList();
   }
 
@@ -164,10 +164,10 @@ public class EnvironmentContext {
   public @NotNull Optional<SystemContext> system(@NotNull String name) {
     Preconditions.checkArgument(name != null, "Name must not be null");
 
-    return this.policy
+    return this.environment.policy()
       .system(name)
       .filter(env -> env.isAccessAllowed(this.subject, EnumSet.of(PolicyPermission.VIEW)))
-      .map(sys -> new SystemContext(sys, this.subject, this.provisioner));
+      .map(sys -> new SystemContext(sys, this.subject, this.environment.provisioner()));
   }
 
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/EnvironmentContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/EnvironmentContext.java
@@ -77,9 +77,13 @@ public class EnvironmentContext {
    * Export the environment policy. Requires EXPORT access.
    */
   public Optional<PolicyDocumentSource> export() {
+    //
+    // NB. Load and return original source to ensure that
+    // any formatting and comments are retained.
+    //
     return NullaryOptional
       .ifTrue(canExport())
-      .map(() -> PolicyDocumentSource.fromPolicy(this.environment.policy()));
+      .map(() -> this.environment.loadPolicy());
   }
 
   /**

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Environment.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Environment.java
@@ -88,5 +88,5 @@ public abstract class Environment {
   /**
    * Load the raw, unparsed policy from file or backing store.
    */
-  protected abstract PolicyDocumentSource loadPolicy();
+  public abstract PolicyDocumentSource loadPolicy();
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentRegistry.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/EnvironmentRegistry.java
@@ -78,7 +78,7 @@ class EnvironmentRegistry {
           options.cacheDuration()
         ) {
           @Override
-          protected PolicyDocumentSource loadPolicy() {
+          public PolicyDocumentSource loadPolicy() {
             return cfg.loadPolicy();
           }
         };

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/Environments.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/Environments.java
@@ -49,7 +49,7 @@ public class Environments {
 
         return (Environment)new Environment(p.name(), p.description(), provisioner, Duration.ofDays(1)) {
           @Override
-          protected PolicyDocumentSource loadPolicy() {
+          public PolicyDocumentSource loadPolicy() {
             return PolicyDocumentSource.fromPolicy(p);
           }
         };

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestEnvironmentContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestEnvironmentContext.java
@@ -189,6 +189,8 @@ public class TestEnvironmentContext {
   @Test
   public void export() {
     var environment = Mockito.mock(Environment.class);
+    when(environment.loadPolicy())
+      .thenReturn(PolicyDocumentSource.fromString("original yaml"));
     when(environment.policy())
       .thenReturn(new EnvironmentPolicy(
         "env",
@@ -205,6 +207,7 @@ public class TestEnvironmentContext {
 
     assertTrue(context.canExport());
     assertTrue(context.export().isPresent());
+    assertEquals("original yaml", context.export().get().yaml());
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Load and return original source when exporting the policy so that formatting and comments are retained