### PR TITLE
Revert "Bump com.google.apis:google-api-services-iam in /sources (#629)"

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-iam</artifactId>
-      <version>v2-rev20241114-2.0.0</version>
+      <version>v1-rev20240725-2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>


### PR DESCRIPTION
This reverts commit 89bdbf6f828074f5a9015fec1b80c6c97a4c2ba8 because it inadvertently switched from the v1 to the v2 IAM API.