### PR TITLE
b/433135671 Enable groups for GKE RBAC

### DIFF
--- a/doc/site/sources/docs/policy-reference.md
+++ b/doc/site/sources/docs/policy-reference.md
@@ -185,9 +185,12 @@ environment:
 
 `gkeEnabled` **Optional** (Default: `false`)
 
-:   When set to `true`, JIT Groups automatically adds the Cloud Identity group to `gke-security-groups`
-    so that it can be used for
-    [Google Kubernetes Engine RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac).
+:   When set to `true`, JIT Groups configures the group so that it can be used for
+    [Google Kubernetes Engine RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac):
+
+    +   The Cloud Identity group's access settings are relaxed so that members of the group are 
+        allowed to list all group members.
+    +   The Cloud Identity group is added to `gke-security-groups`.
 
 `access` **Optional**
 

--- a/doc/site/sources/docs/policy-reference.md
+++ b/doc/site/sources/docs/policy-reference.md
@@ -151,7 +151,7 @@ A JIT group represents a job function or role and bundles all access that's requ
 perform this job function or role.
 
 
-```yaml hl_lines="7-12"
+```yaml hl_lines="7-13"
 ...
 environment:
   ...
@@ -160,6 +160,7 @@ environment:
     groups:
     - name: "datamart-admins"
       description: "Admin-level access to data and stuff"
+      gkeEnabled: true
       access: []
       constraints:
         join: []
@@ -181,6 +182,12 @@ environment:
 
 :   Text that describes the purpose of the JIT group. The text is shown in the user interface and
     is for informational purposes only.
+
+`gkeEnabled` **Optional** (Default: `false`)
+
+:   When set to `true`, JIT Groups automatically adds the Cloud Identity group to `gke-security-groups`
+    so that it can be used for
+    [Google Kubernetes Engine RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac).
 
 `access` **Optional**
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/apis/clients/CloudIdentityGroupsClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/apis/clients/CloudIdentityGroupsClient.java
@@ -633,6 +633,21 @@ public class CloudIdentityGroupsClient {
   }
 
   /**
+   * Permanently add a member to a group in an idempotent way.
+   */
+  public @NotNull MembershipId addPermanentMembership(
+    @NotNull GroupId groupId,
+    @NotNull IamPrincipalId member
+  ) throws AccessException, IOException {
+    var client = createClient();
+    return addMembership(
+      client,
+      lookupGroup(client, groupId),
+      member,
+      null);
+  }
+
+  /**
    * Add a member to a group in an idempotent way.
    */
   public @NotNull MembershipId addMembership(

--- a/sources/src/main/java/com/google/solutions/jitaccess/apis/clients/CloudIdentityGroupsClient.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/apis/clients/CloudIdentityGroupsClient.java
@@ -551,7 +551,7 @@ public class CloudIdentityGroupsClient {
    * Delete a group membership in an idempotent way.
    */
   public void deleteMembership(
-    @NotNull GroupId groupId,
+    @NotNull GroupKey groupKey,
     @NotNull IamPrincipalId member
   ) throws AccessException, IOException {
     var client = createClient();
@@ -564,7 +564,7 @@ public class CloudIdentityGroupsClient {
     {
       membershipId = lookupGroupMembership(
         client,
-        lookupGroup(groupId),
+        groupKey,
         member);
     }
     catch (AccessException e)

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/legacy/LegacyPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/legacy/LegacyPolicy.java
@@ -436,6 +436,7 @@ public class LegacyPolicy extends EnvironmentPolicy {
         acl,
         constraints,
         privileges,
+        false,
         NAME_MAX_LENGTH);
     }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/JitGroupPolicy.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/JitGroupPolicy.java
@@ -38,7 +38,9 @@ import java.util.Map;
 public class JitGroupPolicy extends AbstractPolicy {
   static final String NAME_PATTERN = "^[a-zA-Z0-9\\-]+$";
   static final int NAME_MAX_LENGTH = 24;
+
   private final @NotNull List<Privilege> privileges;
+  private final boolean gkeEnabled;
 
   protected JitGroupPolicy(
     @NotNull String name,
@@ -46,6 +48,7 @@ public class JitGroupPolicy extends AbstractPolicy {
     @Nullable AccessControlList acl,
     @NotNull Map<ConstraintClass, Collection<Constraint>> constraints,
     @NotNull List<Privilege> privileges,
+    boolean gkeEnabled,
     int maxNameLength
   ) {
     super(name, description, acl, constraints);
@@ -60,6 +63,7 @@ public class JitGroupPolicy extends AbstractPolicy {
     Preconditions.checkNotNull(privileges, "Privileges must not be null");
 
     this.privileges = privileges;
+    this.gkeEnabled = gkeEnabled;
   }
 
   public JitGroupPolicy(
@@ -67,9 +71,10 @@ public class JitGroupPolicy extends AbstractPolicy {
     @NotNull String description,
     @Nullable AccessControlList acl,
     @NotNull Map<ConstraintClass, Collection<Constraint>> constraints,
-    @NotNull List<Privilege> privileges
+    @NotNull List<Privilege> privileges,
+    boolean gkeEnabled
   ) {
-    this(name, description, acl, constraints, privileges, NAME_MAX_LENGTH);
+    this(name, description, acl, constraints, privileges, gkeEnabled, NAME_MAX_LENGTH);
   }
 
   public JitGroupPolicy(
@@ -77,14 +82,14 @@ public class JitGroupPolicy extends AbstractPolicy {
     @NotNull String description,
     @Nullable AccessControlList acl
   ) {
-    this(name, description, acl, Map.of(), List.of());
+    this(name, description, acl, Map.of(), List.of(), false);
   }
 
   public JitGroupPolicy(
     @NotNull String name,
     @NotNull String description
   ) {
-    this(name, description, null, Map.of(), List.of());
+    this(name, description, null, Map.of(), List.of(), false);
   }
 
   /**
@@ -110,6 +115,13 @@ public class JitGroupPolicy extends AbstractPolicy {
    */
   public @NotNull Collection<Privilege> privileges() {
     return this.privileges;
+  }
+
+  /**
+   * Indicates if this group can be used for GKE RBAC.
+   */
+  public boolean isGkeEnabled() {
+    return this.gkeEnabled;
   }
 
   /**

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/policy/PolicyDocument.java
@@ -490,7 +490,8 @@ public class PolicyDocument {
     @JsonProperty("description") String description,
     @JsonProperty("access") List<AccessControlEntryElement> acl,
     @JsonProperty("constraints") ConstraintsElement constraints,
-    @JsonProperty("privileges") PrivilegesElement privileges
+    @JsonProperty("privileges") PrivilegesElement privileges,
+    @JsonProperty("gkeEnabled") boolean gkeEnabled
   ) {
 
     static GroupElement toYaml(@NotNull JitGroupPolicy policy) {
@@ -510,7 +511,8 @@ public class PolicyDocument {
             .stream()
             .filter(p -> p instanceof IamRoleBinding)
             .map(p -> IamRoleBindingElement.toYaml((IamRoleBinding)p))
-            .toList()));
+            .toList()),
+        policy.isGkeEnabled());
     }
 
     @NotNull Optional<JitGroupPolicy> toPolicy(@NotNull IssueCollection issues) {
@@ -548,7 +550,8 @@ public class PolicyDocument {
                 .stream()
                 .map(Optional::get)
                 .map(b -> (Privilege)b)
-                .toList());
+                .toList(),
+              this.gkeEnabled);
           }
           catch (Exception e) {
             issues.error(

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
@@ -294,6 +294,12 @@ public class Provisioner {
 
 
         //TODO: Add (and remove!) from gke-security-groups (w/o expiry, w/ view permission)
+        // - gke-security-groups uses the primary domain, not the groups domain
+        // - Skip and log if gke-security-groups doesn't exist
+        //
+        //   call searchGroup "gke-security-groups", if found:
+        // - ON -> call addMembership(groupId, principalId)
+        // - OFF -> call  overload deleteMembership(groupId, principalId) -> handles 404
       }
       catch (AccessException e) {
         this.logger.error(

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
@@ -292,6 +292,7 @@ public class Provisioner {
           groupId,
           expiry);
 
+
         //TODO: Add (and remove!) from gke-security-groups (w/o expiry, w/ view permission)
       }
       catch (AccessException e) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
@@ -259,6 +259,13 @@ public class Provisioner {
       // Create group if it doesn't exist yet.
       //
       try {
+        //
+        // Choose access settings based on whether this group is intended to use for GKE RBAC.
+        //
+        var accessProfile = group.isGkeEnabled()
+          ? CloudIdentityGroupsClient.AccessProfile.GkeCompatible
+          : CloudIdentityGroupsClient.AccessProfile.Restricted;
+
         var groupKey = this.groupsClient.createGroup(
           groupId,
           CloudIdentityGroupsClient.GroupType.Security,
@@ -267,7 +274,8 @@ public class Provisioner {
             group.id().environment(),
             group.id().system(),
             group.id().name()),
-          group.description());
+          group.description(),
+          accessProfile);
 
         //
         // Add user to group.
@@ -283,6 +291,8 @@ public class Provisioner {
           member,
           groupId,
           expiry);
+
+        //TODO: Add (and remove!) from gke-security-groups (w/o expiry, w/ view permission)
       }
       catch (AccessException e) {
         this.logger.error(

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
@@ -298,7 +298,7 @@ public class Provisioner {
           expiry);
 
         //
-        // TODO: Test - GKE-enable (or disable) the group.
+        // GKE-enable (or disable) the group.
         //
         var gkeSecurityGroup = this.groupsClient
           .searchGroupsByPrefix(GKE_SECURITY_GROUPS_PREFIX, false)

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
@@ -321,10 +321,11 @@ public class Provisioner {
             new GroupKey(gkeSecurityGroup.get().getName()),
             groupId);
         }
-        else {
+        else if (group.isGkeEnabled()) {
           this.logger.warn(
             EventIds.PROVISION_MEMBER,
-            "GKE-enabling the group %s failed because there is no group that matches '%s'",
+            "GKE-enabling the group %s failed because the Cloud Identity account doesn't" +
+              " contain any group that matches '%s'.",
             groupId,
             GKE_SECURITY_GROUPS_PREFIX);
         }

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/provisioning/Provisioner.java
@@ -54,7 +54,7 @@ public class Provisioner {
   /**
    * Prefix used by GKE to identify the group that contains all RBAC-enabled groups.
    */
-  private static final @NotNull String GKE_SECURITY_GROUPS_PREFIX = "gke-security-groups@";
+  static final @NotNull String GKE_SECURITY_GROUPS_PREFIX = "gke-security-groups@";
 
   private final @NotNull String environmentName;
   private final @NotNull GroupProvisioner groupProvisioner;

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
@@ -638,6 +639,65 @@ public class ITestCloudIdentityGroupsClient {
     //
     // Check deletion was effective.
     //
+    assertThrows(
+      ResourceNotFoundException.class,
+      () -> client.getMembership(id));
+  }
+
+  //---------------------------------------------------------------------
+  // deleteMembership - by ID.
+  //---------------------------------------------------------------------
+
+  @Test
+  public void deleteMembership_byId_whenGroupIdInvalid() throws AccessException, IOException {
+    var client = new CloudIdentityGroupsClient(
+      ITestEnvironment.APPLICATION_CREDENTIALS,
+      new CloudIdentityGroupsClient.Options(
+        ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
+      HttpTransport.Options.DEFAULT);
+
+    client.deleteMembership(NONEXISTING_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER);
+  }
+
+  @Test
+  public void deleteMembership_byId_whenMembershipNotFound() throws AccessException, IOException {
+    var client = new CloudIdentityGroupsClient(
+      ITestEnvironment.APPLICATION_CREDENTIALS,
+      new CloudIdentityGroupsClient.Options(
+        ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
+      HttpTransport.Options.DEFAULT);
+
+    client.createGroup(
+      TEMPORARY_ACCESS_GROUP_EMAIL,
+      CloudIdentityGroupsClient.GroupType.DiscussionForum,
+      "name",
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
+
+    client.deleteMembership(TEMPORARY_ACCESS_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER);
+  }
+
+  @Test
+  public void deleteMembership_byId() throws AccessException, IOException {
+    var client = new CloudIdentityGroupsClient(
+      ITestEnvironment.APPLICATION_CREDENTIALS,
+      new CloudIdentityGroupsClient.Options(
+        ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
+      HttpTransport.Options.DEFAULT);
+
+    var groupId = client.createGroup(
+      TEMPORARY_ACCESS_GROUP_EMAIL,
+      CloudIdentityGroupsClient.GroupType.DiscussionForum,
+      "name",
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
+    var id = client.addMembership(
+      groupId,
+      ITestEnvironment.TEMPORARY_ACCESS_USER,
+      Instant.now().plusSeconds(300));
+
+    client.deleteMembership(TEMPORARY_ACCESS_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER);
+
     assertThrows(
       ResourceNotFoundException.class,
       () -> client.getMembership(id));

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
@@ -26,6 +26,9 @@ import com.google.solutions.jitaccess.auth.EndUserId;
 import com.google.solutions.jitaccess.auth.GroupId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -120,7 +123,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
 
     assertEquals(
       groupKey,
@@ -183,7 +187,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
     var group = client.getGroup(TEMPORARY_ACCESS_GROUP_EMAIL);
 
     assertEquals(TEMPORARY_ACCESS_GROUP_EMAIL.email, group.getGroupKey().getId());
@@ -208,7 +213,8 @@ public class ITestCloudIdentityGroupsClient {
         new GroupId("test@example.com"),
         CloudIdentityGroupsClient.GroupType.DiscussionForum,
         "name",
-        "description"));
+        "description",
+        CloudIdentityGroupsClient.AccessProfile.Restricted));
   }
 
   @Test
@@ -225,11 +231,15 @@ public class ITestCloudIdentityGroupsClient {
         new GroupId("doesnotexist@google.com"),
         CloudIdentityGroupsClient.GroupType.DiscussionForum,
         "name",
-        "description"));
+        "description",
+        CloudIdentityGroupsClient.AccessProfile.Restricted));
   }
 
-  @Test
-  public void createGroup_createGroupIsIdempotent() throws Exception {
+  @ParameterizedTest
+  @EnumSource(CloudIdentityGroupsClient.AccessProfile.class)
+  public void createGroup_createGroupIsIdempotent(
+    CloudIdentityGroupsClient.AccessProfile accessProfile
+  ) throws Exception {
     var client = new CloudIdentityGroupsClient(
       ITestEnvironment.APPLICATION_CREDENTIALS,
       new CloudIdentityGroupsClient.Options(ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
@@ -242,7 +252,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      accessProfile);
     client.deleteGroup(oldId);
 
     //
@@ -252,7 +263,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      accessProfile);
     assertNotEquals(oldId, createdId);
 
     //
@@ -262,7 +274,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      accessProfile);
     assertNotEquals(oldId, createdId);
   }
 
@@ -306,7 +319,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
 
     client.patchGroup(createdId, "new description");
 
@@ -375,7 +389,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
 
     var membershipExpiry = Instant.now().plusSeconds(300);
     var id = client.addMembership(
@@ -437,7 +452,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
     var userEmail = ITestEnvironment.TEMPORARY_ACCESS_USER;
 
     //
@@ -461,7 +477,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
 
     assertThrows(
       IllegalArgumentException.class,
@@ -482,7 +499,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
     var userEmail = ITestEnvironment.TEMPORARY_ACCESS_USER;
 
     //
@@ -531,7 +549,8 @@ public class ITestCloudIdentityGroupsClient {
       PERMANENT_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
 
     var userEmail = ITestEnvironment.TEMPORARY_ACCESS_USER;
     client.addPermanentMembership(groupId, userEmail);
@@ -571,7 +590,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
     var id = client.addMembership(
       groupId,
       ITestEnvironment.TEMPORARY_ACCESS_USER,
@@ -619,7 +639,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
     var membershipExpiry = Instant.now().plusSeconds(300);
     client.addMembership(
       groupId,
@@ -731,7 +752,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
     var groups = client.searchGroupsByPrefix(
       "jitaccess-",
       true);
@@ -787,7 +809,8 @@ public class ITestCloudIdentityGroupsClient {
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
-      "description");
+      "description",
+      CloudIdentityGroupsClient.AccessProfile.Restricted);
 
     var groupIds = IntStream.range(1, 200)
       .mapToObj(i -> new GroupId(

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
@@ -649,17 +649,6 @@ public class ITestCloudIdentityGroupsClient {
   //---------------------------------------------------------------------
 
   @Test
-  public void deleteMembership_byId_whenGroupIdInvalid() throws AccessException, IOException {
-    var client = new CloudIdentityGroupsClient(
-      ITestEnvironment.APPLICATION_CREDENTIALS,
-      new CloudIdentityGroupsClient.Options(
-        ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
-      HttpTransport.Options.DEFAULT);
-
-    client.deleteMembership(NONEXISTING_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER);
-  }
-
-  @Test
   public void deleteMembership_byId_whenMembershipNotFound() throws AccessException, IOException {
     var client = new CloudIdentityGroupsClient(
       ITestEnvironment.APPLICATION_CREDENTIALS,
@@ -667,14 +656,14 @@ public class ITestCloudIdentityGroupsClient {
         ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
       HttpTransport.Options.DEFAULT);
 
-    client.createGroup(
+    var groupId = client.createGroup(
       TEMPORARY_ACCESS_GROUP_EMAIL,
       CloudIdentityGroupsClient.GroupType.DiscussionForum,
       "name",
       "description",
       CloudIdentityGroupsClient.AccessProfile.Restricted);
 
-    client.deleteMembership(TEMPORARY_ACCESS_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER);
+    client.deleteMembership(groupId, ITestEnvironment.TEMPORARY_ACCESS_USER);
   }
 
   @Test
@@ -696,7 +685,7 @@ public class ITestCloudIdentityGroupsClient {
       ITestEnvironment.TEMPORARY_ACCESS_USER,
       Instant.now().plusSeconds(300));
 
-    client.deleteMembership(TEMPORARY_ACCESS_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER);
+    client.deleteMembership(groupId, ITestEnvironment.TEMPORARY_ACCESS_USER);
 
     assertThrows(
       ResourceNotFoundException.class,

--- a/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/apis/clients/ITestCloudIdentityGroupsClient.java
@@ -48,6 +48,10 @@ public class ITestCloudIdentityGroupsClient {
     String.format(
       "jitaccess-test-permanent@%s",
       ITestEnvironment.CLOUD_IDENTITY_DOMAIN));
+  private static final GroupId NONEXISTING_GROUP_EMAIL = new GroupId(
+    String.format(
+      "jitaccess-test-nonexisting@%s",
+      ITestEnvironment.CLOUD_IDENTITY_DOMAIN));
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -427,7 +431,7 @@ public class ITestCloudIdentityGroupsClient {
   }
 
   @Test
-  public void addMembership_whenGroupIdInvalid_thenThrowsException() {
+  public void addMembership_whenGroupKeyInvalid_thenThrowsException() {
     var client = new CloudIdentityGroupsClient(
       ITestEnvironment.NO_ACCESS_CREDENTIALS,
       new CloudIdentityGroupsClient.Options(
@@ -439,6 +443,21 @@ public class ITestCloudIdentityGroupsClient {
       () -> client.addMembership(
         new GroupKey("invalid"),
         new EndUserId("user@example.com"),
+        Instant.now().plusSeconds(300)));
+  }
+
+  @Test
+  public void addMembership_whenGroupIdInvalid_thenThrowsException() throws Exception {
+    var client = new CloudIdentityGroupsClient(
+      ITestEnvironment.APPLICATION_CREDENTIALS,
+      new CloudIdentityGroupsClient.Options(ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
+      HttpTransport.Options.DEFAULT);
+
+    assertThrows(
+      AccessDeniedException.class,
+      () -> client.addMembership(
+        NONEXISTING_GROUP_EMAIL,
+        ITestEnvironment.TEMPORARY_ACCESS_USER,
         Instant.now().plusSeconds(300)));
   }
 
@@ -537,6 +556,19 @@ public class ITestCloudIdentityGroupsClient {
   //---------------------------------------------------------------------
   // addPermanentMembership.
   //---------------------------------------------------------------------
+
+  @Test
+  public void addPermanentMembership_whenGroupIdInvalid_thenThrowsException() throws Exception {
+    var client = new CloudIdentityGroupsClient(
+      ITestEnvironment.APPLICATION_CREDENTIALS,
+      new CloudIdentityGroupsClient.Options(ITestEnvironment.CLOUD_IDENTITY_ACCOUNT_ID),
+      HttpTransport.Options.DEFAULT);
+
+    assertThrows(
+      AccessDeniedException.class,
+      () -> client.addPermanentMembership(
+        NONEXISTING_GROUP_EMAIL, ITestEnvironment.TEMPORARY_ACCESS_USER));
+  }
 
   @Test
   public void addPermanentMembership() throws Exception {

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/Policies.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/Policies.java
@@ -42,7 +42,7 @@ public class Policies {
       "Env 1",
       new com.google.solutions.jitaccess.catalog.policy.Policy.Metadata("test", Instant.EPOCH));
     var system = new SystemPolicy("sys-1", "");
-    var group = new JitGroupPolicy(name, "", acl, constraints, privileges);
+    var group = new JitGroupPolicy(name, "", acl, constraints, privileges, false);
 
     environment.add(system);
     system.add(group);

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestCatalog.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestCatalog.java
@@ -123,7 +123,8 @@ public class TestCatalog {
         .deny(SAMPLE_USER, PolicyPermission.VIEW.toMask())
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     systemPolicy.add(groupPolicy);
     environmentPolicy.add(systemPolicy);
 
@@ -145,7 +146,8 @@ public class TestCatalog {
         .allow(SAMPLE_USER, PolicyPermission.VIEW.toMask())
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     systemPolicy.add(groupPolicy);
     environmentPolicy.add(systemPolicy);
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestJitGroupContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestJitGroupContext.java
@@ -138,7 +138,8 @@ public class TestJitGroupContext {
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(createFailingConstraint("join")),
         Policy.ConstraintClass.APPROVE, List.of(createFailingConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -170,7 +171,8 @@ public class TestJitGroupContext {
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(createFailingConstraint("join")),
         Policy.ConstraintClass.APPROVE, List.of(createFailingConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -201,7 +203,8 @@ public class TestJitGroupContext {
         .build(),
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(createUnsatisfiedConstraint("join"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -232,7 +235,8 @@ public class TestJitGroupContext {
         .build(),
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(createSatisfiedConstraint("join"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -296,7 +300,8 @@ public class TestJitGroupContext {
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(createFailingConstraint("join")),
         Policy.ConstraintClass.APPROVE, List.of(createFailingConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -325,7 +330,8 @@ public class TestJitGroupContext {
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(),
         Policy.ConstraintClass.APPROVE, List.of()),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -392,7 +398,8 @@ public class TestJitGroupContext {
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1))),
         Policy.ConstraintClass.APPROVE, List.of()),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -434,7 +441,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_USER, PolicyPermission.APPROVE_SELF.toMask())
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -466,7 +474,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -508,7 +517,8 @@ public class TestJitGroupContext {
             "join-constraint",
             List.of(),
             "false"))), // Unsatisfied
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -552,7 +562,8 @@ public class TestJitGroupContext {
 
         Policy.ConstraintClass.APPROVE,
         List.of(createUnsatisfiedConstraint("approve-constraint"))), // Unsatisfied -> does not matter here
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -660,7 +671,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_USER, PolicyPermission.APPROVE_SELF.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createSatisfiedConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -698,7 +710,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createSatisfiedConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -736,7 +749,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_APPROVER_GROUP, PolicyPermission.APPROVE_OTHERS.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createFailingConstraint("failing"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -775,7 +789,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createFailingConstraint("failing"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -812,7 +827,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createUnsatisfiedConstraint("failing"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -850,7 +866,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createSatisfiedConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -924,7 +941,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createFailingConstraint("failing"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -958,7 +976,8 @@ public class TestJitGroupContext {
         .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
         .build(),
       Map.of(Policy.ConstraintClass.APPROVE, List.of(createUnsatisfiedConstraint("failing"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")
@@ -994,7 +1013,8 @@ public class TestJitGroupContext {
       Map.of(
         Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofSeconds(30), Duration.ofMinutes(2))),
         Policy.ConstraintClass.APPROVE, List.of(createSatisfiedConstraint("approve"))),
-      List.of());
+      List.of(),
+      false);
 
     createEnvironmentPolicy()
       .add(new SystemPolicy("system-1", "System")

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestSystemContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestSystemContext.java
@@ -54,7 +54,8 @@ public class TestSystemContext {
           SAMPLE_USER,
           PolicyPermission.VIEW.toMask()))),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     var deniedGroupPolicy = new JitGroupPolicy(
       "group-1",
       "Group 1",
@@ -62,7 +63,8 @@ public class TestSystemContext {
         .deny(SAMPLE_USER, -1)
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     systemPolicy.add(allowedGroupPolicy);
     systemPolicy.add(deniedGroupPolicy);
     environmentPolicy.add(systemPolicy);
@@ -99,7 +101,8 @@ public class TestSystemContext {
         .deny(SAMPLE_USER, PolicyPermission.VIEW.toMask())
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     systemPolicy.add(groupPolicy);
     environmentPolicy.add(systemPolicy);
 
@@ -128,7 +131,8 @@ public class TestSystemContext {
         .allow(SAMPLE_USER, PolicyPermission.VIEW.toMask())
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     systemPolicy.add(groupPolicy);
     environmentPolicy.add(systemPolicy);
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestJitGroupPolicy.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestJitGroupPolicy.java
@@ -113,7 +113,8 @@ public class TestJitGroupPolicy {
       "description",
       AccessControlList.EMPTY,
       Map.of(),
-      privileges);
+      privileges,
+      false);
 
     assertEquals(privileges, group.privileges());
   }
@@ -129,7 +130,8 @@ public class TestJitGroupPolicy {
       "description",
       AccessControlList.EMPTY,
       Map.of(),
-      List.of());
+      List.of(),
+      false);
 
     assertTrue(group.accessControlList().isPresent());
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestSystemPolicy.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/policy/TestSystemPolicy.java
@@ -75,7 +75,8 @@ public class TestSystemPolicy {
       "description",
       AccessControlList.EMPTY,
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     system.add(group);
     assertThrows(IllegalArgumentException.class, () -> system.add(group));
   }
@@ -103,7 +104,8 @@ public class TestSystemPolicy {
       "description",
       AccessControlList.EMPTY,
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     system.add(group);
 
     assertTrue(system.group("group-1").isPresent());

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/provisioning/TestProvisioner.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/provisioning/TestProvisioner.java
@@ -186,7 +186,7 @@ public class TestProvisioner {
   }
 
   @Nested
-  public static class GroupProvisioner {
+  public class GroupProvisioner {
 
     // -------------------------------------------------------------------------
     // cloudIdentityGroupId.
@@ -423,7 +423,7 @@ public class TestProvisioner {
   }
   
   @Nested
-  public static class IamProvisioner {
+  public class IamProvisioner {
 
     // -------------------------------------------------------------------------
     // replaceBindingsForPrincipals.

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/provisioning/TestProvisioner.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/provisioning/TestProvisioner.java
@@ -366,6 +366,10 @@ public class TestProvisioner {
         .thenReturn(new GroupKey("1"));
       when(groupsClient.getGroup(eq(SAMPLE_GROUP)))
         .thenReturn(new Group());
+      when(groupsClient.searchGroupsByPrefix(eq(Provisioner.GKE_SECURITY_GROUPS_PREFIX), eq(false)))
+        .thenReturn(List.of(new Group()
+            .setName("groups/gke")
+          .setGroupKey(new EntityKey().setId(Provisioner.GKE_SECURITY_GROUPS_PREFIX))));
 
       var provisioner = new Provisioner.GroupProvisioner(
         mapping,
@@ -387,6 +391,13 @@ public class TestProvisioner {
         eq(new GroupKey("1")),
         eq(SAMPLE_USER_1),
         eq(expiry));
+
+      verify(groupsClient, times(gkeEnabled ? 1 : 0)).addPermanentMembership(
+        new GroupKey("groups/gke"),
+        SAMPLE_GROUP);
+      verify(groupsClient, times(gkeEnabled ? 0 : 1)).deleteMembership(
+        new GroupKey("groups/gke"),
+        SAMPLE_GROUP);
     }
 
     //---------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestSystemsResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestSystemsResource.java
@@ -151,7 +151,8 @@ public class TestSystemsResource {
           SAMPLE_USER,
           PolicyPermission.VIEW.toMask()))),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     var deniedGroup = new JitGroupPolicy(
       "denied-1",
       "Denied 1",
@@ -159,7 +160,8 @@ public class TestSystemsResource {
         .deny(SAMPLE_USER, -1)
         .build(),
       Map.of(),
-      List.of());
+      List.of(),
+      false);
     system.add(allowedGroup);
     system.add(deniedGroup);
     environment.add(system);
@@ -190,19 +192,22 @@ public class TestSystemsResource {
       "Two",
       AccessControlList.EMPTY,
       Map.of(),
-      List.of()));
+      List.of(),
+      false));
     system.add(new JitGroupPolicy(
       "group-3",
       "Three",
       AccessControlList.EMPTY,
       Map.of(),
-      List.of()));
+      List.of(),
+      false));
     system.add(new JitGroupPolicy(
       "z-group-1",
       "One",
       AccessControlList.EMPTY,
       Map.of(),
-      List.of()) {
+      List.of(),
+      false) {
       @Override
       public @NotNull String displayName() {
         return "group-1";


### PR DESCRIPTION
* Introduce `gkeEnabled` to control whether a group should be usable for GKE RBAC
* Automatically add (or remove) the group to `gke-security-groups`  to expose it to GKE
* Relax access settings for GKE-enabled groups to comply with the GKE requirements